### PR TITLE
release: finalize v0.3.0 (gate-review fixes + release notes)

### DIFF
--- a/docs/release_notes/v0.3.0.md
+++ b/docs/release_notes/v0.3.0.md
@@ -1,6 +1,6 @@
-# wbt v0.3.0 (draft)
+# wbt v0.3.0
 
-> Release date: TBD
+> Release date: 2026-05-29
 > Crate tag: `crate-v0.3.0` · Python tag: `v0.3.0`
 
 ## Summary
@@ -165,9 +165,10 @@ sorted analogously inside `value_to_py`. The helper still recursively handles
   existing `is_good_strategy` suite. Full Rust suite: **200 passed**.
 - Python: new `python/tests/test_result.py` (18 tests — DTO field shapes, unit conventions,
   cached_property laziness, `to_dict(full=True)` JSON-safety, vol-norm/monthly numerical
-  regression); `test_plotting.py` rewritten to the `BacktestResult` contract (26 tests);
-  `test_generate_backtest_report.py` updated for the rewired generator. Full Python suite:
-  **258 passed / 1 skipped** (no regression).
+  regression); `test_plotting.py` rewritten to the `BacktestResult` contract — now all
+  single-purpose figures, no subplots (27 tests, incl. a pnl-axis unit regression);
+  `test_generate_backtest_report.py` updated for the CSS-grid generator. Full Python suite:
+  **259 passed / 1 skipped** (no regression).
 - `python/scripts/quick_start.ipynb` executes end-to-end (now self-contained via
   `mock_weights`).
 
@@ -189,21 +190,32 @@ sorted analogously inside `value_to_py`. The helper still recursively handles
 - New `WbtError::InvalidInput` variant: additive (no existing match-arm needs to change
   because all consumers go through `Display` to `PyException::new_err`).
 
-## Release checklist outcome (preliminary)
+## Release checklist outcome
 
 - **§1 SemVer**: 0.x MINOR bump (`0.2.3 → 0.3.0`). The plotting API change is breaking;
   in 0.x a breaking change is signalled by a MINOR bump and explicitly flagged here.
-- **§2 Lint/typecheck**: `cargo fmt --check`, `cargo clippy --all --tests -D warnings -A non_snake_case`,
-  `cargo test --lib` (193 passed), `ruff format --check`, `ruff check`, `basedpyright` all clean.
+- **§2 Lint/typecheck**: `cargo fmt --check`, `cargo clippy --all -D warnings -A non_snake_case`,
+  `cargo test --lib` (**200 passed**), `ruff format --check`, `ruff check`, `basedpyright` all clean.
+  `cargo publish --dry-run` packaging is clean (91 files); the `--dry-run` *verify build* fails to
+  link on macOS arm64 (`__Py_NoneStruct` undefined) — this is the expected pyo3 `extension-module`
+  cdylib limitation on macOS (symbols resolved at runtime by the interpreter) and is **not a release
+  blocker**: the crate is published on Linux CI (`release-crate.yml`), where undefined cdylib symbols
+  are permitted, as proven by every prior `crate-v*` release.
 - **§3 Tests**: see above.
-- **§4 LLM review**: 15 findings from a deep code review (panic paths, false-positive
-  conditions, semantic mismatches, contract drift) — all fixed in this draft; details
-  in the PR description.
+- **§4 LLM review**: two passes. (a) Deep review of the `BacktestResult` + Rust pairs-aggregation
+  work — 15 findings (panic paths, false-positive conditions, semantic mismatches, contract drift),
+  all fixed. (b) Pre-release gate review of the chart-split work — 1 high (`H1`: `plot_pairs_pnl_dist`
+  applied `tickformat=".1%"` to the `pnl_pct` *percentage* field, a 100× axis blow-up — **fixed**,
+  axis now labelled `(%)` with no fraction formatter, locked by a regression test), 2 medium fixed
+  (`M1` plotly.js inlining is now robust to a failing first panel; `M3` `HtmlReportBuilder.render()`
+  auto-finalizes pending chart tabs), 1 low fixed (`L1` panel-error HTML is now escaped). Non-blocking
+  noted: `M2` the two duplicate 年化收益 metric cards are pre-existing and test-locked; `L2`
+  `month_win_rate` excludes zero-trade months by design.
 - **§5 doc-vs-code (four-way consistency)**: `wbt/__init__.py` exports `BacktestResult` &
   the DTO dataclasses; `_wbt.pyi` adds `aggregated_pairs` / `key_trades`; `README.md` /
-  `README_CN.md` "Plotting" and "Outputs" sections rewritten to the `BacktestResult` API;
-  `python/scripts/quick_start.ipynb` migrated to `result` inputs and made self-contained.
-  `STATS_FIELD_ORDER` unchanged.
+  `README_CN.md` / `python/README*.md` "Plotting" sections rewritten to the single-figure
+  `BacktestResult` API (composite charts removed); `python/scripts/quick_start.ipynb` migrated to
+  `result` inputs, single figures, and made self-contained. `STATS_FIELD_ORDER` unchanged.
 
 ## Known issues (carried forward from v0.2.0)
 

--- a/python/tests/test_plotting.py
+++ b/python/tests/test_plotting.py
@@ -100,6 +100,12 @@ class TestPlotPairsPnlDist:
     def test_to_html(self, result):
         assert isinstance(plot_pairs_pnl_dist(result, to_html=True), str)
 
+    def test_pnl_axis_is_percent_number_not_fraction(self, result):
+        """pnl_pct 是百分数（1.0==1%），x 轴不能用 ".1%"（会再 ×100，放大 100 倍）。"""
+        fig = plot_pairs_pnl_dist(result)
+        assert fig.layout.xaxis.tickformat in (None, "")
+        assert "%" in (fig.layout.xaxis.title.text or "")
+
 
 class TestPlotPairsHoldDist:
     def test_returns_figure(self, result):

--- a/python/wbt/plotting/trades.py
+++ b/python/wbt/plotting/trades.py
@@ -39,7 +39,8 @@ def plot_pairs_pnl_dist(
         )
 
     apply_default_layout(fig, title=title, height=400)
-    fig.update_xaxes(title_text="盈亏比例", tickformat=".1%")
+    # pnl_pct 已是百分数（1.0 == 1%，见 result.PairsDist），轴按 (%) 直接显示，不能用 tickformat=".1%"
+    fig.update_xaxes(title_text="盈亏比例 (%)")
     fig.update_yaxes(title_text="频次")
     return figure_to_html(fig) if to_html else fig
 

--- a/python/wbt/report/_generator.py
+++ b/python/wbt/report/_generator.py
@@ -6,6 +6,7 @@
 
 from __future__ import annotations
 
+import html
 import os
 from typing import Any
 
@@ -91,7 +92,8 @@ def _safe_panel(name: str, build, *, include_plotlyjs: bool) -> str:
         fig.update_layout(autosize=True)
         return fig.to_html(include_plotlyjs=include_plotlyjs, full_html=False, config=_PLOT_CONFIG)
     except Exception as e:  # noqa: BLE001 — 面板级隔离，故意吞掉单图异常
-        return f"<div style='padding:20px;text-align:center;color:red;'>{name}生成失败: {e}</div>"
+        msg = html.escape(f"{name}生成失败: {e}")
+        return f"<div style='padding:20px;text-align:center;color:red;'>{msg}</div>"
 
 
 # 每个标签页的面板定义：(标签名, [(小标题, 构图函数, 是否整行跨列), ...])
@@ -141,13 +143,17 @@ def _generate_chart_tabs(result: BacktestResult) -> list[tuple[str, list[tuple[s
     plotly.js 仅在全局第一个面板内联一次，其余面板复用，控制报告体积。
     """
     tabs: list[tuple[str, list[tuple[str, str, bool]]]] = []
-    first = True
+    plotlyjs_emitted = False
     for tab_name, panels in _tab_specs(result):
         items: list[tuple[str, str, bool]] = []
         for sub_title, build, full_width in panels:
-            html = _safe_panel(sub_title, build, include_plotlyjs=first)
-            items.append((sub_title, html, full_width))
-            first = False
+            include = not plotlyjs_emitted
+            panel_html = _safe_panel(sub_title, build, include_plotlyjs=include)
+            # 仅当面板真正内联了 plotly.js（未在异常路径降级）才标记，否则下个面板继续尝试内联，
+            # 避免首个面板失败导致整份报告无 plotly.js、所有图静默不渲染。
+            if include and "Plotly" in panel_html:
+                plotlyjs_emitted = True
+            items.append((sub_title, panel_html, full_width))
         tabs.append((tab_name, items))
     return tabs
 

--- a/python/wbt/report/html_builder.py
+++ b/python/wbt/report/html_builder.py
@@ -665,6 +665,11 @@ class HtmlReportBuilder:
 
         :return: HTML 字符串
         """
+        # 兜底：若调用方添加了图表标签页却忘了 add_charts_section()，自动收口，
+        # 否则这些 chart_tab（以 dict 暂存）会被下方静默跳过，生成无图报告。
+        if any(s[0] == "chart_tab" for s in self.sections):
+            self.add_charts_section()
+
         all_css = self.base_css + "\n" + "\n".join(self.custom_css)
 
         header_html = ""


### PR DESCRIPTION
## 目的
0.3.0 发版前置：落实 §4 全仓 review 的修复 + 定稿 release notes。配合先 crate 后 Python 的 tag 发布。

## 改动
**Gate-review 修复（plotting 拆图部分）**
- **H1（高，阻塞）**：`plot_pairs_pnl_dist` 误对 `pnl_pct`（百分数字段，`1.0==1%`）用 `tickformat=".1%"`，x 轴放大 100×。改为轴标 `(%)`、去掉小数格式器，加回归断言。
- **M1（中）**：`generate_backtest_report` 的 plotly.js 内联对「首个面板异常」健壮化（只有真正内联成功才停止尝试）。
- **M3（中）**：`HtmlReportBuilder.render()` 在有未收口 `chart_tab` 时自动 `add_charts_section()`，消除公共 API 漏调用→图表静默丢失的陷阱。
- **L1（低）**：面板错误信息插入 HTML 前 `html.escape`。
- M2/L2 非阻塞，已在 release notes 记录。

**release notes**：`v0.3.0-draft.md` → `v0.3.0.md`，填日期、写两轮 review 结论 + cargo dry-run 在 macOS 的非阻塞说明、更新测试计数。

## 验证
- `ruff format/check`、`basedpyright` 全绿
- `pytest`：**259 passed / 1 skipped**
- `cargo fmt/clippy/test --lib`（200 passed）；`cargo publish --dry-run` 打包合规（macOS verify-build 链接为已知 pyo3 限制，非阻塞）