### PR TITLE
fix(result): 归一超额改为 norm(多头) − norm(基准)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wbt"
-version = "0.3.0"
+version = "0.3.1"
 edition = "2024"
 description = "Weight-based backtesting engine for quantitative trading"
 license = "MIT"

--- a/docs/release_notes/v0.3.1.md
+++ b/docs/release_notes/v0.3.1.md
@@ -1,0 +1,53 @@
+# wbt v0.3.1
+
+> Release date: 2026-05-30
+> Crate tag: `crate-v0.3.1` · Python tag: `v0.3.1`
+
+## Summary
+
+PATCH release. Single semantic fix to the volatility-normalized **excess** curve
+introduced in 0.3.0.
+
+## Fix: `curves_voladj['超额']` = `norm(多头) − norm(基准)`
+
+`BacktestResult.curves_voladj['超额']` previously normalized the **raw excess**
+series as a whole — `norm(wb.alpha['超额'])`, i.e. compute the original excess
+(策略 − 基准) first, then scale it by its own volatility.
+
+That is inconsistent with the volatility-normalized comparison chart, which shows
+the normalized 多头 and 基准 curves side by side: the displayed 多头 curve
+(`curves['多头']`, from `dailys` `long_return`) is **not** the same series as
+alpha's internal 策略 (measured correlation ≈ 0.96, not 1.0), so the old excess
+line did not equal the visual gap between the two normalized lines.
+
+0.3.1 redefines it as **normalize 多头 and 基准 each to `target_vol` first, then
+subtract daily**:
+
+```
+curves_voladj['超额'].daily == curves_voladj['多头'].daily − curves_voladj['基准'].daily
+```
+
+The normalized excess curve now exactly equals the difference of the two
+normalized lines on the chart. Its annualized volatility is no longer pinned to
+`target_vol` (it depends on the 多头/基准 correlation) — this is expected.
+
+Only `curves_voladj['超额']` changes. The raw `curves['超额']`, `stats_by_side`,
+`is_good_strategy`, and all other outputs are unchanged.
+
+## Tests
+
+- `python/tests/test_result.py`: `test_curves_voladj_hits_target_vol` now excludes
+  `超额` from the target-vol assertion; new `test_curves_voladj_excess_is_diff`
+  locks `归一超额 == 归一多头 − 归一基准` (atol 1e-12). Full Python suite:
+  **260 passed / 1 skipped**.
+
+## Compatibility
+
+- Behavioral change limited to `BacktestResult.curves_voladj['超额']` (a 0.3.0
+  feature). No public API signature change; no Rust change. `STATS_FIELD_ORDER`
+  unchanged.
+- Python ≥ 3.10; Rust edition 2024, `pyo3 = 0.28` / `numpy = 0.28` (unchanged).
+
+## Known issues (carried forward from v0.2.0)
+
+Unchanged; see `docs/release_notes/v0.2.0.md`.

--- a/python/tests/test_result.py
+++ b/python/tests/test_result.py
@@ -178,16 +178,27 @@ def test_stats_by_side_keys(result: BacktestResult) -> None:
 # K 数值回归
 # ---------------------------------------------------------------------------
 def test_curves_voladj_hits_target_vol(result: BacktestResult) -> None:
-    """波动率归一后，各曲线年化波动率 ≈ target_vol（非退化序列）。"""
+    """波动率归一后各曲线年化波动率 ≈ target_vol（非退化序列）。
+
+    「超额」例外：它是 norm(多头) − norm(基准) 之差，波动率取决于两者相关性，
+    不再等于 target_vol，故单独排除（其口径由 test_curves_voladj_excess_is_diff 校验）。
+    """
     target = 0.20
     sqrt_yd = float(np.sqrt(result.yearly_days))
     for key, c in result.curves_voladj.items():
-        if c.daily.size <= 1:
+        if key == "超额" or c.daily.size <= 1:
             continue
         annual_vol = float(np.std(c.daily, ddof=1)) * sqrt_yd
         if annual_vol == 0:
             continue
         assert annual_vol == pytest.approx(target, rel=1e-6), key
+
+
+def test_curves_voladj_excess_is_diff(result: BacktestResult) -> None:
+    """归一超额 == 归一多头 − 归一基准（先各自归一化、再相减）。"""
+    va = result.curves_voladj
+    expected = va["多头"].daily - va["基准"].daily
+    np.testing.assert_allclose(va["超额"].daily, expected, rtol=0, atol=1e-12)
 
 
 def test_monthly_z_rows_match_yearly_totals(result: BacktestResult) -> None:

--- a/python/wbt/result.py
+++ b/python/wbt/result.py
@@ -299,14 +299,23 @@ class BacktestResult:
     # -------------------------------------------------------- cached (按需)
     @cached_property
     def curves_voladj(self) -> dict[str, Curve]:
-        """波动率归一后的同名曲线；scale = target_vol / (daily.std · √yearly_days)。"""
+        """波动率归一后的同名曲线；scale = target_vol / (daily.std · √yearly_days)。
+
+        「超额」特殊处理：定义为 ``norm(多头) − norm(基准)``（多头、基准先各自归一化、
+        再逐日相减），而非对原始超额(策略−基准)整体归一化。这样归一超额曲线恰好等于
+        图上归一化多头与归一化基准两条线之差，口径自洽；其年化波动率不再等于 target_vol。
+        """
         out: dict[str, Curve] = {}
         sqrt_yd = float(np.sqrt(self.yearly_days))
         for key, c in self.curves.items():
+            if key == "超额":
+                continue  # 由 norm(多头) − norm(基准) 派生，循环结束后单独构造
             std = float(np.std(c.daily, ddof=1)) if c.daily.size > 1 else 0.0
             annual_vol = std * sqrt_yd
             scale = (self._target_vol / annual_vol) if annual_vol > 0 else 1.0
             out[key] = _build_curve(c.daily * scale)
+        if "多头" in out and "基准" in out:
+            out["超额"] = _build_curve(out["多头"].daily - out["基准"].daily)
         return out
 
     @cached_property


### PR DESCRIPTION
## 问题
`BacktestResult.curves_voladj['超额']` 原实现是 **先算原始超额(策略−基准)、再整体归一化**（`norm(wb.alpha['超额'])`）。正确定义应为 **多头、基准先各自波动率归一化、再逐日相减**（`norm(多头) − norm(基准)`）。

`curves['多头']`（dailys long_return）与 alpha 内部「策略」并非同源（实测相关 0.96、非 1.0），两种口径数值不同：原口径用原始超额自身波动(≈0.175)整体缩放，与图上展示的归一多头/基准两条线不自洽。

## 修复
- `result.py::curves_voladj`：超额单独由 `norm(多头) − norm(基准)` 派生，使归一超额曲线恰好等于对比图上归一多头与归一基准之差。其年化波动率不再等于 `target_vol`（取决于两者相关性），属预期。
- `test_result`：`test_curves_voladj_hits_target_vol` 放行超额；新增 `test_curves_voladj_excess_is_diff` 锁定 `归一超额 == 归一多头 − 归一基准`。

## 验证
- ruff/basedpyright 全绿；pytest **260 passed / 1 skipped**。
- 实测：归一多头 vol=0.20、归一基准 vol=0.20、归一超额 == norm(多头)−norm(基准)（atol 1e-12）。