### PR TITLE
feat(core): key_trades 选榜按真实持仓段去重（merge_holding_segments）

### DIFF
--- a/python/tests/test_key_trades_merge.py
+++ b/python/tests/test_key_trades_merge.py
@@ -1,0 +1,165 @@
+"""验证 key_trades 的「真实持仓段合并去重」（任务 t101322）。
+
+main 原本按 (symbol, 开仓时间, 平仓时间) 精确聚合选榜，无法合并 LIFO 撮合对同一段
+持仓的拆分（同开分批平 / 分批开同平）。本次改为选榜前先用并查集把 open 或 close 任一
+相同的聚合记录传递合并成真实持仓段。
+
+这里用一份完全独立的纯 Python 实现复刻 aggregate→merge→select 链，对随机多场景与
+Rust 的 wb.key_trades 输出逐行比对，校验数值正确性；并验证去重的关键不变量。
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pandas as pd
+
+from wbt import WeightBacktest
+
+
+def _uf_find(parent: list[int], x: int) -> int:
+    while parent[x] != x:
+        parent[x] = parent[parent[x]]
+        x = parent[x]
+    return x
+
+
+def _uf_union(parent: list[int], a: int, b: int) -> None:
+    ra, rb = _uf_find(parent, a), _uf_find(parent, b)
+    if ra != rb:
+        parent[ra] = rb
+
+
+def _ref_merge(agg: pd.DataFrame) -> list[tuple]:
+    """独立实现：把 aggregated_pairs 按真实持仓段合并。
+
+    返回段集合 (symbol, dir, open, close, profit, hold, count)。
+    """
+    segs: list[tuple] = []
+    for (sym, direction), grp in agg.groupby(["symbol", "交易方向"]):
+        g = grp.reset_index(drop=True)
+        n = len(g)
+        parent = list(range(n))
+        o_seen: dict = {}
+        c_seen: dict = {}
+        for i in range(n):
+            o, c = g.loc[i, "开仓时间"], g.loc[i, "平仓时间"]
+            if o in o_seen:
+                _uf_union(parent, i, o_seen[o])
+            else:
+                o_seen[o] = i
+            if c in c_seen:
+                _uf_union(parent, i, c_seen[c])
+            else:
+                c_seen[c] = i
+        comp: dict[int, list[int]] = {}
+        for i in range(n):
+            comp.setdefault(_uf_find(parent, i), []).append(i)
+        for members in comp.values():
+            rep = min(members, key=lambda i: (-int(g.loc[i, "持仓K线数"]), g.loc[i, "开仓时间"]))
+            cnt = sum(int(g.loc[i, "count"]) for i in members)
+            segs.append(
+                (
+                    sym,
+                    direction,
+                    g.loc[rep, "开仓时间"],
+                    g.loc[rep, "平仓时间"],
+                    round(float(g.loc[rep, "盈亏比例"]), 4),
+                    int(g.loc[rep, "持仓K线数"]),
+                    cnt,
+                )
+            )
+    return sorted(segs)
+
+
+def _kt_segs(kt: pd.DataFrame) -> list[tuple]:
+    """key_trades（去 year/kind 去重）→ 段集合。"""
+    segs = {
+        (
+            r["symbol"],
+            r["交易方向"],
+            r["开仓时间"],
+            r["平仓时间"],
+            round(float(r["盈亏比例"]), 4),
+            int(r["持仓K线数"]),
+            int(r["count"]),
+        )
+        for _, r in kt.iterrows()
+    }
+    return sorted(segs)
+
+
+def _ref_board(segs: list[tuple], top: int) -> dict:
+    """复刻 select_key_trades：按平仓年份 best 降序 / worst 升序，worst 剔除已入 best。"""
+    by_year: dict[int, list[tuple]] = {}
+    for s in segs:
+        by_year.setdefault(pd.Timestamp(s[3]).year, []).append(s)
+    out: dict = {}
+    for y, items in by_year.items():
+        best = sorted(items, key=lambda s: (-s[4], s[2]))[:top]
+        best_set = set(best)
+        worst = [s for s in sorted(items, key=lambda s: (s[4], s[2])) if s not in best_set][:top]
+        # Rust 端空的 best/worst 不产生行，参照也应跳过空列表，保证 dict 键集合一致。
+        if best:
+            out[(y, "best")] = sorted(round(s[4], 4) for s in best)
+        if worst:
+            out[(y, "worst")] = sorted(round(s[4], 4) for s in worst)
+    return out
+
+
+def _kt_board(kt: pd.DataFrame) -> dict:
+    out: dict = {}
+    for (y, kind), g in kt.groupby(["year", "kind"]):
+        out[(int(y), kind)] = sorted(round(float(x), 4) for x in g["盈亏比例"])
+    return out
+
+
+def _make_bt(rng: np.random.Generator) -> WeightBacktest:
+    rows = []
+    for sym in ["AAA", "BBB", "CCC"][: rng.integers(1, 4)]:
+        year = int(rng.choice([2022, 2023, 2024]))
+        for dd in range(int(rng.integers(6, 40))):
+            w = round(float(rng.choice([-0.5, -0.25, 0.0, 0.0, 0.25, 0.5])), 2)
+            rows.append(
+                {
+                    "dt": f"{year}-{1 + dd // 28:02d}-{1 + dd % 28:02d} 09:30:00",
+                    "symbol": sym,
+                    "weight": w,
+                    "price": round(100.0 + float(rng.normal(0, 3)), 4),
+                }
+            )
+    return WeightBacktest(pd.DataFrame(rows), digits=2, n_jobs=1)
+
+
+def test_key_trades_merge_matches_reference() -> None:
+    """随机多场景：合并段集合与年度选榜均须与独立参照逐行一致。"""
+    rng = np.random.default_rng(20240618)
+    checked = 0
+    for _ in range(60):
+        bt = _make_bt(rng)
+        agg = bt.aggregated_pairs
+        if agg.empty:
+            continue
+        checked += 1
+        top = int(rng.integers(1, 5))
+        ref_segs = _ref_merge(agg)
+        assert ref_segs == _kt_segs(bt.key_trades(top=10**9)), "合并段集合与参照不一致"
+        assert _ref_board(ref_segs, top) == _kt_board(bt.key_trades(top=top)), "年度选榜与参照不一致"
+    assert checked >= 15, f"有效随机场景过少（{checked}）"
+
+
+def test_key_trades_dedups_lifo_split() -> None:
+    """同 open 分批平仓（LIFO 拆成多条聚合记录）在 key_trades 里只上榜一次。"""
+    # 单 symbol，建仓后分两批平仓 → aggregated_pairs 多条同 open、不同 close。
+    rows = []
+    for i, w in enumerate([0.5, 0.5, 0.25, 0.0]):
+        rows.append({"dt": f"2024-03-{i + 1:02d} 09:30:00", "symbol": "AAA", "weight": w, "price": 100.0 + i})
+    bt = WeightBacktest(pd.DataFrame(rows), digits=2, n_jobs=1)
+    agg = bt.aggregated_pairs
+    kt = bt.key_trades(top=10)
+    seg = kt.drop(columns=["year", "kind"]).drop_duplicates()
+    # 合并只会减少或持平：真实持仓段数 <= 聚合记录数。
+    assert len(seg) <= len(agg)
+    # 不变量：同 (symbol, 交易方向) 的开仓/平仓时间各自唯一。
+    for _, gp in seg.groupby(["symbol", "交易方向"]):
+        assert gp["开仓时间"].is_unique
+        assert gp["平仓时间"].is_unique

--- a/src/core/key_trades.rs
+++ b/src/core/key_trades.rs
@@ -12,7 +12,8 @@
 use crate::core::errors::WbtError;
 use crate::core::native_engine::{PairsSoA, dt_to_date_key_fast};
 use polars::prelude::*;
-use std::collections::BTreeMap;
+use std::collections::hash_map::Entry;
+use std::collections::{BTreeMap, HashMap};
 
 /// 一条聚合后的开平记录。
 #[derive(Debug, Clone, PartialEq)]
@@ -203,12 +204,15 @@ pub fn key_trades_to_df(
     agg: &[AggRow],
     top: usize,
 ) -> Result<DataFrame, WbtError> {
-    let selected = select_key_trades(agg, top, pairs.time_unit);
+    // 选榜前先把 LIFO 拆分的同一段持仓还原为真实持仓段（按 open_dt 或 close_dt 任一相同
+    // 传递合并），避免同段被重复枚举、重复上榜。aggregated_pairs 仍用未合并的 agg，语义不变。
+    let merged = merge_holding_segments(agg);
+    let selected = select_key_trades(&merged, top, pairs.time_unit);
     agg_rows_to_columns(
         pairs,
         selected
             .into_iter()
-            .map(|(y, kind, i)| (Some((y, kind)), agg[i].clone())),
+            .map(|(y, kind, i)| (Some((y, kind)), merged[i].clone())),
     )
 }
 
@@ -220,6 +224,99 @@ pub fn aggregated_pairs_df(pairs: &PairsSoA) -> Result<DataFrame, WbtError> {
 /// 每年最赚/最亏各 `top` 笔关键交易（聚合 + 物化，便于单测/单次调用）。
 pub fn key_trades_df(pairs: &PairsSoA, top: usize) -> Result<DataFrame, WbtError> {
     key_trades_to_df(pairs, &aggregate_pairs(pairs), top)
+}
+
+/// 并查集 find（路径压缩）。
+fn uf_find(parent: &mut [usize], mut x: usize) -> usize {
+    while parent[x] != x {
+        parent[x] = parent[parent[x]];
+        x = parent[x];
+    }
+    x
+}
+
+/// 并查集 union。
+fn uf_union(parent: &mut [usize], a: usize, b: usize) {
+    let (ra, rb) = (uf_find(parent, a), uf_find(parent, b));
+    if ra != rb {
+        parent[ra] = rb;
+    }
+}
+
+/// 把 `aggregate_pairs` 的结果按真实持仓段进一步合并，用于 `key_trades` 选榜。
+///
+/// `aggregate_pairs` 仅按 `(symbol, open_dt, close_dt)` 精确聚合，无法合并 LIFO 撮合
+/// 对同一段持仓的拆分：一次开仓分批平仓（同 `open_dt`、不同 `close_dt`）、分批开仓一次
+/// 平仓（不同 `open_dt`、同 `close_dt`）。本函数按 `(sym_id, dir)` 分组，对 `open_dt`
+/// 或 `close_dt` 任一相同的记录用并查集做传递合并（覆盖 A-B 同开、B-C 同平的链式合并）；
+/// 每个连通分量取持仓 K 线数最长的一笔为代表，`count` 取成员之和，其余字段（含
+/// `profit_bp`——同 `(open,close)` 价格一致，已是 ±(close/open−1)·1e4）直接取代表笔。
+///
+/// 不变量：输出中同 `(sym_id, dir)` 的 `open_dt`、`close_dt` 各自唯一——任意两条同
+/// `open_dt`（或同 `close_dt`）必被并入同一分量，不会落到两个代表笔上。
+pub fn merge_holding_segments(agg: &[AggRow]) -> Vec<AggRow> {
+    let n = agg.len();
+    if n == 0 {
+        return Vec::new();
+    }
+
+    let mut parent: Vec<usize> = (0..n).collect();
+    // 用 (sym_id, dir, dt) 作映射键，天然隔离不同 (sym, dir) 组。
+    let mut open_seen: HashMap<(u32, &'static str, i64), usize> = HashMap::with_capacity(n);
+    let mut close_seen: HashMap<(u32, &'static str, i64), usize> = HashMap::with_capacity(n);
+    for (i, r) in agg.iter().enumerate() {
+        match open_seen.entry((r.sym_id, r.dir, r.open_dt)) {
+            Entry::Occupied(e) => uf_union(&mut parent, i, *e.get()),
+            Entry::Vacant(e) => {
+                e.insert(i);
+            }
+        }
+        match close_seen.entry((r.sym_id, r.dir, r.close_dt)) {
+            Entry::Occupied(e) => uf_union(&mut parent, i, *e.get()),
+            Entry::Vacant(e) => {
+                e.insert(i);
+            }
+        }
+    }
+
+    // 按连通分量根聚合：选代表笔（hold_bars 最长，平局取 open_dt 更早以稳定）+ 累加 count。
+    let mut rep: HashMap<usize, usize> = HashMap::new();
+    let mut count_sum: HashMap<usize, i64> = HashMap::new();
+    for (i, r) in agg.iter().enumerate() {
+        let root = uf_find(&mut parent, i);
+        *count_sum.entry(root).or_insert(0) += r.count;
+        match rep.get(&root) {
+            None => {
+                rep.insert(root, i);
+            }
+            Some(&cur) => {
+                let better = r.hold_bars > agg[cur].hold_bars
+                    || (r.hold_bars == agg[cur].hold_bars && r.open_dt < agg[cur].open_dt);
+                if better {
+                    rep.insert(root, i);
+                }
+            }
+        }
+    }
+
+    let mut out: Vec<AggRow> = rep
+        .iter()
+        .map(|(&root, &idx)| {
+            let mut row = agg[idx].clone();
+            row.count = count_sum[&root];
+            row
+        })
+        .collect();
+
+    // 稳定输出顺序，便于下游与测试。
+    out.sort_by(|a, b| {
+        a.sym_id
+            .cmp(&b.sym_id)
+            .then_with(|| a.dir.cmp(b.dir))
+            .then_with(|| a.open_dt.cmp(&b.open_dt))
+            .then_with(|| a.close_dt.cmp(&b.close_dt))
+    });
+    out
 }
 
 #[cfg(test)]
@@ -359,5 +456,144 @@ mod tests {
         assert!(df.column("kind").is_ok());
         assert!(df.column("symbol").is_ok());
         assert_eq!(df.height(), 1, "1 笔 → 仅 best 1（worst 去重后为空）");
+    }
+
+    // ---- merge_holding_segments：真实持仓段合并（任务 t101322 新增） ----
+
+    /// 构造 AggRow 切片。每条用 (sym_id, dir, open_dt, close_dt, hold_bars, profit_bp, count)。
+    fn make_agg(rows: &[(u32, &'static str, i64, i64, i64, f64, i64)]) -> Vec<AggRow> {
+        rows.iter()
+            .map(
+                |&(sym_id, dir, open_dt, close_dt, hold_bars, profit_bp, count)| AggRow {
+                    sym_id,
+                    open_dt,
+                    close_dt,
+                    dir,
+                    open_price: 100.0,
+                    close_price: 110.0,
+                    hold_bars,
+                    profit_bp,
+                    count,
+                },
+            )
+            .collect()
+    }
+
+    /// 同 open、分批平仓（同 open 不同 close）应合并为一段：代表取持仓最长笔，count 求和。
+    #[test]
+    fn merge_same_open_split_close() {
+        let agg = make_agg(&[
+            (0, "多头", 100, 200, 5, 10.0, 2),
+            (0, "多头", 100, 300, 8, 20.0, 3),
+        ]);
+        let m = merge_holding_segments(&agg);
+        assert_eq!(m.len(), 1, "同 open 的两条应合并为一段");
+        assert_eq!(m[0].hold_bars, 8, "代表取持仓 K 线数最长者");
+        assert_eq!(m[0].close_dt, 300);
+        assert_eq!(m[0].profit_bp, 20.0, "profit 取代表笔");
+        assert_eq!(m[0].count, 5, "count 取成员之和 2+3");
+    }
+
+    /// 传递合并：A-B 同 open、B-C 同 close 应并成一段。
+    #[test]
+    fn merge_transitive() {
+        let agg = make_agg(&[
+            (0, "多头", 100, 200, 5, 10.0, 1),
+            (0, "多头", 100, 400, 9, 99.0, 2),
+            (0, "多头", 300, 400, 4, 30.0, 3),
+        ]);
+        let m = merge_holding_segments(&agg);
+        assert_eq!(m.len(), 1, "A-B 同开、B-C 同平应链式合并");
+        assert_eq!(m[0].hold_bars, 9);
+        assert_eq!(m[0].open_dt, 100);
+        assert_eq!(m[0].close_dt, 400);
+        assert_eq!(m[0].count, 6, "1+2+3");
+    }
+
+    /// 独立段（open、close 均不同）不应合并。
+    #[test]
+    fn merge_independent_not_merged() {
+        let agg = make_agg(&[
+            (0, "多头", 100, 150, 5, 10.0, 1),
+            (0, "多头", 200, 250, 5, 20.0, 1),
+        ]);
+        assert_eq!(merge_holding_segments(&agg).len(), 2);
+    }
+
+    /// 同 open、同 close 但不同 symbol 或不同方向，不应跨组合并。
+    #[test]
+    fn merge_sym_and_dir_isolation() {
+        let by_sym = make_agg(&[
+            (0, "多头", 100, 200, 5, 10.0, 1),
+            (1, "多头", 100, 200, 5, 20.0, 1),
+        ]);
+        assert_eq!(
+            merge_holding_segments(&by_sym).len(),
+            2,
+            "不同 symbol 不合并"
+        );
+        let by_dir = make_agg(&[
+            (0, "多头", 100, 200, 5, 10.0, 1),
+            (0, "空头", 100, 200, 5, 20.0, 1),
+        ]);
+        assert_eq!(merge_holding_segments(&by_dir).len(), 2, "不同方向不合并");
+    }
+
+    /// 不变量：输出中同 (sym, dir) 的 open_dt、close_dt 各自唯一。
+    #[test]
+    fn merge_invariant_unique_open_close() {
+        let agg = make_agg(&[
+            (0, "多头", 100, 200, 5, 10.0, 1),
+            (0, "多头", 100, 400, 9, 99.0, 2),
+            (0, "多头", 300, 400, 4, 30.0, 3),
+            (0, "空头", 500, 600, 3, -5.0, 4),
+            (1, "多头", 100, 200, 2, 7.0, 5),
+        ]);
+        let m = merge_holding_segments(&agg);
+        use std::collections::HashSet;
+        let mut opens: HashSet<(u32, &str, i64)> = HashSet::new();
+        let mut closes: HashSet<(u32, &str, i64)> = HashSet::new();
+        for s in &m {
+            assert!(opens.insert((s.sym_id, s.dir, s.open_dt)), "open_dt 重复");
+            assert!(
+                closes.insert((s.sym_id, s.dir, s.close_dt)),
+                "close_dt 重复"
+            );
+        }
+    }
+
+    #[test]
+    fn merge_empty() {
+        assert!(merge_holding_segments(&[]).is_empty());
+    }
+
+    /// 端到端：LIFO 拆成多条 AggRow 的同一段持仓，key_trades 去重后只上榜一次。
+    #[test]
+    fn key_trades_dedups_lifo_split() {
+        // 同 sym 同 open，分两次平仓（close 不同但同年）→ aggregate 后 2 条，merge 后 1 段。
+        let pairs = make_pairs(
+            &[
+                (0, DT_2024, DT_2024, 5, 100.0, 1),
+                (0, DT_2024, DT_2024B, 8, 300.0, 1),
+            ],
+            vec!["A".into()],
+        );
+        assert_eq!(
+            aggregate_pairs(&pairs).len(),
+            2,
+            "aggregate 按 close 区分仍是 2 条"
+        );
+        let df = key_trades_df(&pairs, 3).unwrap();
+        assert_eq!(df.height(), 1, "LIFO 拆分的同段去重后只上榜一次");
+        assert_eq!(
+            df.column("count").unwrap().i64().unwrap().get(0),
+            Some(2),
+            "count=1+1"
+        );
+        assert_eq!(
+            df.column("盈亏比例").unwrap().f64().unwrap().get(0),
+            Some(300.0),
+            "profit 取代表笔（持仓最长）"
+        );
     }
 }

--- a/src/core/key_trades.rs
+++ b/src/core/key_trades.rs
@@ -249,8 +249,10 @@ fn uf_union(parent: &mut [usize], a: usize, b: usize) {
 /// 对同一段持仓的拆分：一次开仓分批平仓（同 `open_dt`、不同 `close_dt`）、分批开仓一次
 /// 平仓（不同 `open_dt`、同 `close_dt`）。本函数按 `(sym_id, dir)` 分组，对 `open_dt`
 /// 或 `close_dt` 任一相同的记录用并查集做传递合并（覆盖 A-B 同开、B-C 同平的链式合并）；
-/// 每个连通分量取持仓 K 线数最长的一笔为代表，`count` 取成员之和，其余字段（含
-/// `profit_bp`——同 `(open,close)` 价格一致，已是 ±(close/open−1)·1e4）直接取代表笔。
+/// 每个连通分量取持仓 K 线数最长的一笔为代表，`count` 取成员之和；`profit_bp` /
+/// `open_price` / `close_price` 等价格类字段直接取代表笔——同一连通分量的成员之间
+/// 至多共享 open 或 close 中的一端，价格未必相等；选榜语义下「持仓最长的那段」即
+/// 「最具代表性」的主升段，足以代表整段持仓的展示口径，故不再按价格重算。
 ///
 /// 不变量：输出中同 `(sym_id, dir)` 的 `open_dt`、`close_dt` 各自唯一——任意两条同
 /// `open_dt`（或同 `close_dt`）必被并入同一分量，不会落到两个代表笔上。


### PR DESCRIPTION
## 背景


main（v0.3.0）的 `key_trades` 按 `(symbol, 开仓时间, 平仓时间)` 精确聚合（`aggregate_pairs`）后选榜。但引擎 LIFO 撮合会把同一段真实持仓拆成多条记录：
- 一次开仓、分批平仓 → 同 `open_dt`、不同 `close_dt`；
- 分批开仓、一次平仓 → 不同 `open_dt`、同 `close_dt`。

精确聚合无法合并这两种拆分，导致同一段持仓在年度最赚/最亏榜被重复枚举、重复上榜。

## 改动（最小增量，接口零变化）

仅改 [src/core/key_trades.rs](src/core/key_trades.rs)：
- 新增 `merge_holding_segments(agg)`：在 `aggregate_pairs` 结果之上，按 `(sym_id, dir)` 分组，用并查集对 `open_dt` 或 `close_dt` 任一相同的记录**传递合并**（覆盖 A-B 同开、B-C 同平的链式合并）；连通分量取持仓 K 线数最长的一笔为代表，`count` 取成员之和，`profit_bp` 取代表笔（同 open+close 价格一致，已是 ±(close/open−1)·1e4，无需重算）。
- `key_trades_to_df` 选榜前先调 `merge_holding_segments`。

**`aggregate_pairs` / `aggregated_pairs` 维持原 `(open, close)` 聚合语义不变**；`key_trades(top=3)` 接口、列结构（`year/kind/...`）、缓存、下游（`plot_key_trades` / `result.key_trades` / report）均不变。`mod.rs` / `lib.rs` / `backtest.py` / `.pyi` 无需改动。

**不变量**：合并输出中同 `(symbol, 方向)` 的开仓、平仓时间各自唯一。

## 验证

- Rust：新增 7 单测（同开分批平合并 / 传递合并 / 独立段不并 / sym+dir 隔离 / 唯一性不变量 / 空 / 端到端去重）；`cargo fmt + clippy -D warnings + test` 全绿（207 测）。
- Python：新增**差分测试**——独立纯 Python 实现复刻 `aggregate→merge→select` 链，对 60 个随机多场景与 Rust `key_trades` 逐行比对（段集合 + 年度选榜零差异）；外加 LIFO 拆分去重不变量测试。`maturin develop --release` 后 `pytest` 全绿（282 passed, 1 skipped），`ruff` + `basedpyright` 干净。

> 说明：本 PR 最初基于旧 main（当时仓库无 key_trades）写成独立实现，后发现 main 已随 v0.3.0 落地 key_trades 框架，遂改为在其上做最小增量去重，已 rebase 到最新 main。