### PR TITLE
feat(is_good_strategy)!: 回撤并入 OR + min_year_days 默认 200 + 报告双模式判定 (SKZ-9)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wbt"
-version = "0.3.2"
+version = "0.4.0"
 edition = "2024"
 description = "Weight-based backtesting engine for quantitative trading"
 license = "MIT"

--- a/docs/release_notes/v0.4.0.md
+++ b/docs/release_notes/v0.4.0.md
@@ -1,0 +1,63 @@
+# wbt v0.4.0
+
+> Release date: 2026-06-25
+> Crate tag: `crate-v0.4.0` · Python tag: `v0.4.0`
+
+## Summary
+
+MINOR release. **BREAKING** change to `is_good_strategy`'s decision rules and
+return-dict schema (SKZ-9), plus a fuller strategy-verdict section in the HTML
+report covering both `history` and `recent` modes.
+
+## Breaking: `is_good_strategy` decision rules
+
+### `history` mode
+
+- Default `min_year_days` raised **120 → 200**.
+- Each complete calendar year (≥ `min_year_days`) now passes if **any one** of
+  three holds: absolute return > 0, **or** vol-normalized long excess > 0, **or**
+  that year's long-excess max drawdown < `max_dd_threshold`. All complete years
+  passing ⇒ `is_good`.
+- The previous full-sample excess-drawdown hard gate is **removed**; drawdown is
+  now computed per-year and folded into the yearly OR.
+- When alpha is degenerate, the two alpha-derived branches do not participate and
+  `is_good` is forced `false` (unchanged contract).
+
+### `recent` mode
+
+- The tail window passes the return side if **any one** of three holds: absolute
+  return > 0, **or** vol-normalized long excess > 0, **or** recent long-excess max
+  drawdown < `max_dd_threshold`.
+- The only retained AND hard gate: recent max drawdown **strictly less than** the
+  history max drawdown computed after excluding the recent window.
+
+### Return-dict schema changes
+
+- `history`: removed `history_alpha_max_drawdown` and `cond_history_dd_passed`.
+  Each `yearly_metrics` entry now carries `alpha_max_drawdown` (that year's excess
+  drawdown).
+- `recent`: key names unchanged, but `cond_recent_dd_passed` now means only
+  "strictly below history drawdown", and the `< threshold` check moved into the
+  `cond_recent_return_passed` OR.
+
+### Downstream (skz) sync
+
+`describe_review_failure` `reason` text changed; any reference to the removed
+`history_alpha_max_drawdown` / `cond_history_dd_passed` keys must move to
+`yearly_metrics[].alpha_max_drawdown` or be dropped. The `is_good` contract itself
+is unchanged.
+
+## Report: full strategy verdict (history + recent)
+
+`generate_backtest_report` previously rendered only the `history` verdict. The
+"策略审核" tab now shows both a `history` and a `recent` verdict card, plus a
+collapsible "查看详细判定信息" panel (native `<details>`) listing every decision
+field for both modes.
+
+## Tests
+
+- `src/core/is_good_strategy.rs`: rewritten judge tests covering each of the three
+  history OR branches in isolation, the per-year AND, the recent OR, and the
+  strict-history equality boundary (equal ⇒ False).
+- `python/tests/test_is_good_strategy.py`: updated key set; per-year drawdown
+  assertion.

--- a/python/tests/test_generate_backtest_report.py
+++ b/python/tests/test_generate_backtest_report.py
@@ -136,6 +136,18 @@ def test_generate_backtest_report_writes_valid_html(sample_dfw: pd.DataFrame, tm
     assert "wbt 权重回测引擎" in html
 
 
+def test_generate_backtest_report_has_history_and_recent_verdict(sample_dfw: pd.DataFrame, tmp_path: Path) -> None:
+    """策略审核 tab 应同时包含 history / recent 两个模式的判定卡 + 可展开详情。"""
+    out = tmp_path / "r.html"
+    generate_backtest_report(sample_dfw, output_path=str(out), n_jobs=1)
+    html = out.read_text(encoding="utf-8")
+    assert "history 模式（逐年判定）" in html
+    assert "recent 模式（尾部窗口判定）" in html
+    assert "查看详细判定信息" in html  # native <details> 折叠按钮
+    assert '<details class="verdict-details"' in html
+    assert "历史超额回撤(剔除近期)" in html  # recent 卡片表头
+
+
 def test_generate_backtest_report_default_path_in_cwd(
     sample_dfw: pd.DataFrame, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:

--- a/python/tests/test_is_good_strategy.py
+++ b/python/tests/test_is_good_strategy.py
@@ -16,10 +16,8 @@ HISTORY_KEYS = {
     "reason",
     "yearly_metrics",
     "complete_year_count",
-    "history_alpha_max_drawdown",
     "alpha_degenerate",
     "cond_yearly_passed",
-    "cond_history_dd_passed",
 }
 
 RECENT_KEYS = {
@@ -54,6 +52,7 @@ def test_history_mode_returns_expected_keys(wb: WeightBacktest):
             "year",
             "abs_return",
             "alpha_return",
+            "alpha_max_drawdown",
             "days",
             "is_complete_year",
             "year_passed",
@@ -115,12 +114,15 @@ def test_recent_zero_recent_days_raises(wb: WeightBacktest):
     assert "recent_days" in msg or "invalid input" in msg
 
 
-def test_threshold_extreme_changes_judgement(wb: WeightBacktest):
-    """极小阈值让 cond_history_dd_passed=False；极大阈值让其 True。"""
-    relaxed = wb.is_good_strategy(mode="history", max_dd_threshold=1.0)
-    strict = wb.is_good_strategy(mode="history", max_dd_threshold=1e-9)
-    assert strict["cond_history_dd_passed"] is False
-    assert relaxed["cond_history_dd_passed"] is True
+def test_yearly_metrics_carry_per_year_drawdown(wb: WeightBacktest):
+    """回撤已下放为逐年指标：yearly_metrics 每项带出 alpha_max_drawdown。"""
+    r = wb.is_good_strategy(mode="history")
+    ym = r["yearly_metrics"]
+    assert isinstance(ym, list) and ym, "fixture should produce at least one year bucket"
+    for entry in ym:
+        dd = entry["alpha_max_drawdown"]
+        assert isinstance(dd, (int, float)) and not isinstance(dd, bool)
+        assert dd >= 0.0
 
 
 def test_default_parameters_work(wb: WeightBacktest):

--- a/python/wbt/_wbt.pyi
+++ b/python/wbt/_wbt.pyi
@@ -46,7 +46,7 @@ class PyWeightBacktest:
         mode: str = "history",
         target_vol: float = 0.20,
         max_dd_threshold: float = 0.20,
-        min_year_days: int = 120,
+        min_year_days: int = 200,
         recent_days: int = 252,
         min_history_days: int = 60,
     ) -> dict[str, Any]: ...

--- a/python/wbt/backtest.py
+++ b/python/wbt/backtest.py
@@ -385,7 +385,7 @@ class WeightBacktest:
         mode: str = "history",
         target_vol: float = 0.20,
         max_dd_threshold: float = 0.20,
-        min_year_days: int = 120,
+        min_year_days: int = 200,
         recent_days: int = 252,
         min_history_days: int = 60,
     ) -> dict[str, object]:
@@ -393,16 +393,21 @@ class WeightBacktest:
 
         两种判定模式，业务口径与方案子文档一致：
 
-        - ``mode="history"``：每个完整自然年绝对收益 > 0 或波动率归一多头超额 > 0；
-          且全样本多头超额最大回撤 < ``max_dd_threshold``。
-        - ``mode="recent"``：过去 ``recent_days`` 天绝对收益 > 0 或波动率归一多头超额 > 0；
-          且过去窗口多头超额最大回撤 < ``max_dd_threshold`` **且** 严格小于"剔除 recent
-          窗口后"的历史最大回撤。两段计算窗口完全错开。
+        - ``mode="history"``：每个完整自然年（≥ ``min_year_days``）满足**三者之一**即合格——
+          绝对收益 > 0 **或** 波动率归一多头超额 > 0 **或** 当年多头超额最大回撤 <
+          ``max_dd_threshold``；所有完整自然年都合格才 ``is_good``。
+          （回撤条件已从"跨全样本的独立硬门"下放为逐年计算、并入年度 OR；不再有全样本级别的
+          回撤一票否决。）
+        - ``mode="recent"``：尾部 ``recent_days`` 天满足**三者之一**即可——绝对收益 > 0 **或**
+          波动率归一多头超额 > 0 **或** 近期多头超额最大回撤 < ``max_dd_threshold``；
+          **且** 近期最大回撤严格小于"剔除 recent 窗口后"的历史最大回撤（唯一保留的硬门）。
+          两段计算窗口完全错开。
 
         :param mode: 判定模式，``"history"`` 或 ``"recent"``。
         :param target_vol: 波动率归一目标年化波动率（默认 0.20）。
-        :param max_dd_threshold: 多头超额最大回撤阈值（默认 0.20）。
-        :param min_year_days: 视为"完整自然年"所需的最少交易日数（默认 120）。
+        :param max_dd_threshold: 多头超额最大回撤阈值（默认 0.20）。history 模式下为**逐年**
+            回撤阈值，recent 模式下为近期窗口回撤阈值。
+        :param min_year_days: 视为"完整自然年"所需的最少交易日数（默认 200）。
         :param recent_days: ``"recent"`` 模式取序列尾部的日数（默认 252）。
         :param min_history_days: ``"recent"`` 模式下剔除 recent 窗口后的历史段必须达到
             的最小长度，否则 ``history_window_empty=True`` 且 ``is_good=False``
@@ -424,12 +429,16 @@ class WeightBacktest:
             **history / recent 两个模式返回的 key 集合互斥**，按 ``mode`` 字段 dispatch；
             不要假设可以同时拿到两个模式的字段。
 
-            **history 模式必含 key**：``alpha_degenerate``、``cond_history_dd_passed``、
-            ``cond_yearly_passed``、``complete_year_count``、``history_alpha_max_drawdown``
-            （退化时为 ``None``）、``is_good``、``mode``、``reason``、``yearly_metrics``。
+            **history 模式必含 key**：``alpha_degenerate``、``cond_yearly_passed``、
+            ``complete_year_count``、``is_good``、``mode``、``reason``、``yearly_metrics``。
+            ``yearly_metrics`` 每项含 ``year``、``abs_return``、``alpha_return``、
+            ``alpha_max_drawdown``（当年超额回撤）、``days``、``is_complete_year``、
+            ``year_passed``。全样本回撤硬门已取消，``history_alpha_max_drawdown`` /
+            ``cond_history_dd_passed`` 不再返回。
 
-            **recent 模式必含 key**：``alpha_degenerate``、``cond_recent_dd_passed``、
-            ``cond_recent_return_passed``、``history_alpha_max_drawdown_excl_recent``
+            **recent 模式必含 key**：``alpha_degenerate``、``cond_recent_dd_passed``
+            （现仅表示"近期回撤严格小于历史回撤"这一硬门）、``cond_recent_return_passed``
+            （现已并入"近期回撤 < 阈值"的 OR 分支）、``history_alpha_max_drawdown_excl_recent``
             （退化或样本不足时为 ``None``）、``history_window_empty``、``is_good``、
             ``mode``、``reason``、``recent_abs_return``、``recent_actual_days``、
             ``recent_alpha_max_drawdown``（退化时为 ``None``）、``recent_alpha_return``

--- a/python/wbt/plotting/_common.py
+++ b/python/wbt/plotting/_common.py
@@ -40,7 +40,18 @@ def fmt_cell(v: object) -> str:
 _COUNT_KEYS = ("天数", "日数", "次数", "K线数", "间隔", "数量", "days", "count")
 _YEAR_KEYS = ("year", "年份")
 _RATIO_KEYS = ("夏普", "卡玛", "盈亏比", "盈亏平衡", "赢面")
-_PCT_KEYS = ("收益", "回撤", "波动", "胜率", "占比", "回报率", "覆盖", "abs_return", "alpha_return")
+_PCT_KEYS = (
+    "收益",
+    "回撤",
+    "波动",
+    "胜率",
+    "占比",
+    "回报率",
+    "覆盖",
+    "abs_return",
+    "alpha_return",
+    "alpha_max_drawdown",
+)
 
 
 def fmt_value(key: str, v: object) -> str:

--- a/python/wbt/plotting/tables.py
+++ b/python/wbt/plotting/tables.py
@@ -23,6 +23,7 @@ _YEARLY_COLS: list[tuple[str, str]] = [
     ("year", "年份"),
     ("abs_return", "绝对收益"),
     ("alpha_return", "超额收益"),
+    ("alpha_max_drawdown", "超额回撤"),
     ("days", "交易日数"),
     ("is_complete_year", "完整年"),
     ("year_passed", "达标"),

--- a/python/wbt/report/_generator.py
+++ b/python/wbt/report/_generator.py
@@ -135,7 +135,7 @@ def _tab_specs(result: BacktestResult):
         (
             "策略审核",
             [
-                tbl("策略判定 & 年度指标", lambda: ht.verdict_card_html(result)),
+                tbl("策略判定（history + recent）", lambda: ht.verdict_section_html(result)),
                 tbl("回撤明细（Top 10）", lambda: ht.drawdowns_table_html(result)),
                 tbl("完整绩效指标", lambda: ht.stats_kv_html(result)),
             ],

--- a/python/wbt/report/_html_tables.py
+++ b/python/wbt/report/_html_tables.py
@@ -53,17 +53,28 @@ def _fin_table(headers: list[str], rows: list[list[str]]) -> str:
     return f'<div class="fin-wrap"><table class="fin-table"><thead><tr>{head}</tr></thead><tbody>{body}</tbody></table></div>'
 
 
-def verdict_card_html(result: BacktestResult) -> str:
-    """策略判定卡：状态徽章 + 结构化条件清单 + 年度明细表（取代英文 reason 堆叠）。"""
-    v = result.verdict
-    is_good = bool(v.get("is_good"))
-    badge_cls, badge_txt = ("good", "✓ 可用") if is_good else ("bad", "✗ 不可用")
+def _conds_html(conds: list[tuple[str, str, str]]) -> str:
+    """条件清单：(状态 ok/no, 标题, 说明) → .verdict-cond 行。"""
+    return "".join(
+        f'<div class="verdict-cond {st}"><span class="ck">{"✓" if st == "ok" else "✗"}</span>'
+        f'<span class="ct">{html.escape(t)}</span><span class="cd">{html.escape(d)}</span></div>'
+        for st, t, d in conds
+    )
 
-    ym = sorted(v.get("yearly_metrics") or [], key=lambda m: m["year"])
-    dd = v.get("history_alpha_max_drawdown")
-    dd_txt = f"{dd:.2%}" if isinstance(dd, (int, float)) else "—"
+
+def _verdict_head(is_good: bool, sub: str) -> str:
+    badge_cls, badge_txt = ("good", "✓ 可用") if is_good else ("bad", "✗ 不可用")
+    return (
+        f'<div class="verdict-head"><span class="verdict-badge {badge_cls}">{badge_txt}</span>'
+        f'<span class="verdict-sub">{html.escape(sub)}</span></div>'
+    )
+
+
+def history_verdict_card_html(v: dict) -> str:
+    """history 模式判定卡：状态徽章 + 逐年达标条件 + 年度明细表。"""
     ny = v.get("complete_year_count")
     ny_txt = str(ny) if ny is not None else "—"
+    ym = sorted(v.get("yearly_metrics") or [], key=lambda m: m["year"])
 
     conds: list[tuple[str, str, str]] = []
     if "cond_yearly_passed" in v:
@@ -71,18 +82,8 @@ def verdict_card_html(result: BacktestResult) -> str:
         fails = [str(int(m["year"])) for m in ym if m.get("is_complete_year") and not m.get("year_passed")]
         detail = "全部完整年度达标" if ok else ("未达标年度：" + "、".join(fails) if fails else "存在未达标年度")
         conds.append(("ok" if ok else "no", "逐年达标", detail))
-    if "cond_history_dd_passed" in v:
-        ok = bool(v.get("cond_history_dd_passed"))
-        detail = f"超额最大回撤 {dd_txt}，阈值 20%" + ("" if ok else "（已超阈值）")
-        conds.append(("ok" if ok else "no", "超额回撤控制", detail))
     if v.get("alpha_degenerate"):
         conds.append(("no", "alpha 退化", "多头或基准波动率为 0，超额无法定义"))
-
-    cond_html = "".join(
-        f'<div class="verdict-cond {st}"><span class="ck">{"✓" if st == "ok" else "✗"}</span>'
-        f'<span class="ct">{html.escape(t)}</span><span class="cd">{html.escape(d)}</span></div>'
-        for st, t, d in conds
-    )
 
     table_html = ""
     if ym:
@@ -99,20 +100,119 @@ def verdict_card_html(result: BacktestResult) -> str:
                     str(int(m["year"])),
                     _cell("绝对收益", m.get("abs_return")),
                     _cell("超额收益", m.get("alpha_return")),
+                    fmt_value("超额回撤", m.get("alpha_max_drawdown")),
                     fmt_value("交易日数", m.get("days")),
                     badge,
                 ]
             )
-        table_html = _fin_table(["年份", "绝对收益", "超额收益", "交易日数", "达标"], rows)
+        table_html = _fin_table(["年份", "绝对收益", "超额收益", "超额回撤", "交易日数", "达标"], rows)
 
-    sub = f"{ny_txt} 个完整年度 · 超额最大回撤 {dd_txt}"
     return (
         '<div class="verdict">'
-        f'<div class="verdict-head"><span class="verdict-badge {badge_cls}">{badge_txt}</span>'
-        f'<span class="verdict-sub">{html.escape(sub)}</span></div>'
-        f'<div class="verdict-conds">{cond_html}</div>'
+        f"{_verdict_head(bool(v.get('is_good')), f'{ny_txt} 个完整年度')}"
+        f'<div class="verdict-conds">{_conds_html(conds)}</div>'
         f"{table_html}</div>"
     )
+
+
+def recent_verdict_card_html(v: dict) -> str:
+    """recent 模式判定卡：状态徽章 + 收益/回撤条件 + 近期窗口指标表。"""
+    sd, ed = v.get("recent_start_date"), v.get("recent_end_date")
+    days = v.get("recent_actual_days")
+    sub_bits = []
+    if days is not None:
+        sub_bits.append(f"近 {days} 个交易日")
+    if sd and ed:
+        sub_bits.append(f"{sd} ~ {ed}")
+    sub = " · ".join(sub_bits) if sub_bits else "近期窗口"
+
+    conds: list[tuple[str, str, str]] = []
+    if "cond_recent_return_passed" in v:
+        ok = bool(v.get("cond_recent_return_passed"))
+        conds.append(("ok" if ok else "no", "收益/回撤达标", "绝对收益>0 或 超额>0 或 近期回撤<阈值，任一即可"))
+    if "cond_recent_dd_passed" in v:
+        ok = bool(v.get("cond_recent_dd_passed"))
+        conds.append(("ok" if ok else "no", "回撤优于历史", "近期超额回撤严格小于剔除近期后的历史回撤"))
+    if v.get("history_window_empty"):
+        conds.append(("no", "历史窗口不足", "剔除近期窗口后历史样本过短，无法比较回撤"))
+    if v.get("alpha_degenerate"):
+        conds.append(("no", "alpha 退化", "多头或基准波动率为 0，超额无法定义"))
+
+    rows = [
+        [
+            _cell("绝对收益", v.get("recent_abs_return")),
+            _cell("超额收益", v.get("recent_alpha_return")),
+            fmt_value("近期超额回撤", v.get("recent_alpha_max_drawdown")),
+            fmt_value("历史超额回撤", v.get("history_alpha_max_drawdown_excl_recent")),
+        ]
+    ]
+    table_html = _fin_table(["近期绝对收益", "近期超额收益", "近期超额回撤", "历史超额回撤(剔除近期)"], rows)
+
+    return (
+        '<div class="verdict">'
+        f"{_verdict_head(bool(v.get('is_good')), sub)}"
+        f'<div class="verdict-conds">{_conds_html(conds)}</div>'
+        f"{table_html}</div>"
+    )
+
+
+# 详情面板逐字段展示用的字段顺序与中文标签（key 名英文，对人友好的标签在右）。
+_DETAIL_LABELS: dict[str, str] = {
+    "mode": "模式",
+    "is_good": "可用",
+    "complete_year_count": "完整年度数",
+    "cond_yearly_passed": "逐年达标",
+    "cond_recent_return_passed": "近期收益/回撤达标",
+    "cond_recent_dd_passed": "近期回撤优于历史",
+    "recent_start_date": "近期起始",
+    "recent_end_date": "近期结束",
+    "recent_actual_days": "近期实际天数",
+    "recent_abs_return": "近期绝对收益",
+    "recent_alpha_return": "近期超额收益",
+    "recent_alpha_max_drawdown": "近期超额回撤",
+    "history_alpha_max_drawdown_excl_recent": "历史超额回撤(剔除近期)",
+    "history_window_empty": "历史窗口不足",
+    "alpha_degenerate": "alpha 退化",
+    "reason": "原始判定说明",
+}
+
+
+def _detail_kv_grid(v: dict) -> str:
+    items = ""
+    for key, label in _DETAIL_LABELS.items():
+        if key not in v:
+            continue
+        items += (
+            f'<div class="kv"><span class="kv-k">{html.escape(label)}</span>'
+            f'<span class="kv-v">{_cell(key, v[key])}</span></div>'
+        )
+    return f'<div class="kv-grid">{items}</div>'
+
+
+def verdict_section_html(result: BacktestResult) -> str:
+    """策略判定全量报告：history + recent 两张判定卡 + 可展开的逐字段详情。"""
+    history = result.verdict
+    recent = result.verdict_recent
+    details = (
+        '<details class="verdict-details"><summary>查看详细判定信息</summary>'
+        '<div class="verdict-detail-block"><div class="verdict-mode-title">history（逐年）</div>'
+        f"{_detail_kv_grid(history)}</div>"
+        '<div class="verdict-detail-block"><div class="verdict-mode-title">recent（近期窗口）</div>'
+        f"{_detail_kv_grid(recent)}</div></details>"
+    )
+    return (
+        '<div class="verdict-group">'
+        '<div class="verdict-mode-title">history 模式（逐年判定）</div>'
+        f"{history_verdict_card_html(history)}"
+        '<div class="verdict-mode-title">recent 模式（尾部窗口判定）</div>'
+        f"{recent_verdict_card_html(recent)}"
+        f"{details}</div>"
+    )
+
+
+def verdict_card_html(result: BacktestResult) -> str:
+    """向后兼容：单独的 history 判定卡。"""
+    return history_verdict_card_html(result.verdict)
 
 
 def stats_kv_html(result: BacktestResult) -> str:

--- a/python/wbt/report/html_builder.py
+++ b/python/wbt/report/html_builder.py
@@ -268,6 +268,22 @@ class HtmlReportBuilder:
         .verdict-cond.no .ck { color: var(--up); }
         .verdict-cond .ct { color: var(--ink); font-weight: 600; flex: none; }
         .verdict-cond .cd { color: var(--muted); }
+        .verdict-group { display: flex; flex-direction: column; gap: .35rem; }
+        .verdict-mode-title {
+            font-size: .82rem; font-weight: 700; color: var(--muted); letter-spacing: .03em;
+            text-transform: uppercase; margin: .6rem .15rem .1rem;
+        }
+        .verdict-details { margin: .5rem .15rem 0; }
+        .verdict-details > summary {
+            cursor: pointer; user-select: none; font-size: .85rem; font-weight: 600; color: var(--ink);
+            padding: .55rem .85rem; border: 1px solid var(--border); border-radius: 8px; background: var(--panel-2);
+            list-style: none;
+        }
+        .verdict-details > summary::-webkit-details-marker { display: none; }
+        .verdict-details > summary::before { content: "▸ "; color: var(--muted); }
+        .verdict-details[open] > summary::before { content: "▾ "; }
+        .verdict-detail-block { margin-top: .7rem; }
+        .verdict-detail-block .verdict-mode-title { margin-top: 0; }
 
         /* ============ Footer ============ */
         .footer {

--- a/python/wbt/result.py
+++ b/python/wbt/result.py
@@ -373,7 +373,13 @@ class BacktestResult:
 
     @cached_property
     def verdict(self) -> dict:
-        return self._wb.is_good_strategy()
+        """history 模式判定（逐年）。yearly_returns 复用其 yearly_metrics。"""
+        return self._wb.is_good_strategy(mode="history")
+
+    @cached_property
+    def verdict_recent(self) -> dict:
+        """recent 模式判定（尾部 recent_days 天）。"""
+        return self._wb.is_good_strategy(mode="recent")
 
     @cached_property
     def yearly_returns(self) -> YearlyReturns:

--- a/src/core/backtest.rs
+++ b/src/core/backtest.rs
@@ -940,9 +940,11 @@ mod tests {
         assert_eq!(r.get("mode").and_then(|v| v.as_str()), Some("history"));
         assert!(r.get("is_good").and_then(|v| v.as_bool()).is_some());
         assert!(r.contains_key("yearly_metrics"));
-        assert!(r.contains_key("history_alpha_max_drawdown"));
         assert!(r.contains_key("cond_yearly_passed"));
-        assert!(r.contains_key("cond_history_dd_passed"));
+        assert!(r.contains_key("complete_year_count"));
+        // 全样本回撤硬门已取消，相关 key 不再返回。
+        assert!(!r.contains_key("history_alpha_max_drawdown"));
+        assert!(!r.contains_key("cond_history_dd_passed"));
     }
 
     #[test]

--- a/src/core/is_good_strategy.rs
+++ b/src/core/is_good_strategy.rs
@@ -1,15 +1,17 @@
 //! is_good_strategy: 评价策略能不能搞
 //!
 //! 提供两种判定模式：
-//! - `history`：每个完整自然年绝对收益>0 或 波动率归一多头超额>0；且全样本多头超额最大回撤<阈值
-//! - `recent` ：过去一年绝对收益>0 或 波动率归一多头超额>0；且过去一年多头超额最大回撤<阈值 且 <错开 recent 窗口后的历史最大回撤
+//! - `history`：每个完整自然年（≥ `min_year_days`）满足三者之一即合格——
+//!   绝对收益>0 / 波动率归一多头超额>0 / **当年**多头超额最大回撤<阈值；所有完整年都合格才 `is_good`。
+//! - `recent` ：尾部 `recent_days` 天满足三者之一即可——绝对收益>0 / 波动率归一多头超额>0 /
+//!   近期多头超额最大回撤<阈值；**且**近期最大回撤严格小于错开 recent 窗口后的历史最大回撤（唯一硬门）。
 //!
 //! ## 波动率归一化口径（重要）
 //!
 //! [`compute_vol_adjusted_alpha`] 计算的归一化 scale 基于**全样本** long/bench 序列
 //! 的年化标准差，整段共用一组 (long_scale, bench_scale)。这意味着：
 //!
-//! - `Mode::History` 的 `history_alpha_max_drawdown` 在全样本归一化序列上计算 — 与口径一致。
+//! - `Mode::History` 的逐年 `alpha_max_drawdown` 在全样本归一化序列上按年切片计算 — 与口径一致。
 //! - `Mode::Recent` 的 `recent_alpha_max_drawdown` 与
 //!   `history_alpha_max_drawdown_excl_recent` 都是在**同一条**全样本归一化序列上分别取
 //!   尾部 / 头部计算，**不会**对 recent 窗口重新归一化。如果用户期望"recent 窗口按
@@ -44,12 +46,14 @@ pub(crate) enum Mode {
 }
 
 /// 单个完整自然年的指标聚合。`year_passed` 字段由 [`judge`] 主流程根据
-/// 业务条件（绝对收益>0 或 多头超额>0）回填，本算子内默认填 `false`。
+/// 业务条件（绝对收益>0 或 多头超额>0 或 当年超额回撤<阈值）回填，本算子内默认填 `false`。
+/// `alpha_max_drawdown` 是**当年**多头超额日序列的最大回撤绝对值（在全样本归一化序列上按年切片）。
 #[derive(Debug, Clone, PartialEq)]
 pub(crate) struct YearMetric {
     pub year: i32,
     pub abs_return: f64,
     pub alpha_return: f64,
+    pub alpha_max_drawdown: f64,
     pub days: usize,
     pub is_complete_year: bool,
     pub year_passed: bool,
@@ -172,10 +176,12 @@ pub(crate) fn compute_yearly_metrics(
             let days = strat.len();
             let abs_return = strat.iter().fold(1.0_f64, |acc, r| acc * (1.0 + r)) - 1.0;
             let alpha_return = alpha.iter().fold(1.0_f64, |acc, r| acc * (1.0 + r)) - 1.0;
+            let alpha_max_drawdown = local_max_drawdown_abs(&alpha);
             YearMetric {
                 year,
                 abs_return,
                 alpha_return,
+                alpha_max_drawdown,
                 days,
                 is_complete_year: days >= min_year_days,
                 year_passed: false,
@@ -245,11 +251,6 @@ pub(crate) fn compute_recent_window(
         alpha_return,
         alpha_max_drawdown,
     })
-}
-
-/// 全样本 alpha 序列的最大回撤（取绝对值）。用于 `history` 模式条件 B。
-pub(crate) fn compute_history_max_dd_full(alpha_daily: &[f64]) -> f64 {
-    local_max_drawdown_abs(alpha_daily)
 }
 
 /// 剔除尾部 `min(len, recent_days)` 天后计算历史 alpha 最大回撤（取绝对值）。
@@ -346,10 +347,14 @@ pub(crate) fn judge(
 
             let mut yearly =
                 compute_yearly_metrics(date_keys, strategy_daily, &alpha_daily, min_year_days)?;
+            // 逐年三路 OR：绝对收益>ε 或 多头超额>ε 或 当年超额回撤<阈值。
+            // alpha 退化时 alpha 派生两路不参与（避免"全 0 alpha → 回撤 0"凭空通过）。
             for m in yearly.iter_mut() {
                 if m.is_complete_year {
-                    m.year_passed =
-                        m.abs_return > RETURN_EPSILON || m.alpha_return > RETURN_EPSILON;
+                    m.year_passed = m.abs_return > RETURN_EPSILON
+                        || (!alpha_degenerate
+                            && (m.alpha_return > RETURN_EPSILON
+                                || m.alpha_max_drawdown < max_dd_threshold));
                 }
             }
 
@@ -362,8 +367,8 @@ pub(crate) fn judge(
                 for m in &complete {
                     if !m.year_passed {
                         reasons.push(format!(
-                            "year {} both metrics ≤ ε (abs_return={:.6}, alpha_return={:.6})",
-                            m.year, m.abs_return, m.alpha_return
+                            "year {} all three metrics fail (abs_return={:.6}, alpha_return={:.6}, alpha_max_drawdown={:.6} ≥ threshold {:.6})",
+                            m.year, m.abs_return, m.alpha_return, m.alpha_max_drawdown, max_dd_threshold
                         ));
                         ok = false;
                     }
@@ -371,37 +376,15 @@ pub(crate) fn judge(
                 ok
             };
 
-            let history_dd_full = compute_history_max_dd_full(&alpha_daily);
-            // alpha 退化时不让 cond_dd 凭"全 0 alpha → max_dd=0"通过
-            let cond_dd = if alpha_degenerate {
-                false
-            } else {
-                history_dd_full < max_dd_threshold
-            };
-            if !alpha_degenerate && !cond_dd {
-                reasons.push(format!(
-                    "history_alpha_max_drawdown {:.6} ≥ threshold {:.6}",
-                    history_dd_full, max_dd_threshold
-                ));
-            }
-
             out.insert(
                 "yearly_metrics".into(),
                 Value::Array(yearly.iter().map(year_metric_to_value).collect()),
             );
             out.insert("complete_year_count".into(), json!(complete.len()));
-            out.insert(
-                "history_alpha_max_drawdown".into(),
-                if alpha_degenerate {
-                    Value::Null
-                } else {
-                    json!(history_dd_full)
-                },
-            );
             out.insert("alpha_degenerate".into(), json!(alpha_degenerate));
             out.insert("cond_yearly_passed".into(), json!(cond_yearly));
-            out.insert("cond_history_dd_passed".into(), json!(cond_dd));
-            out.insert("is_good".into(), json!(cond_yearly && cond_dd));
+            // 退化时 alpha 派生字段无意义，全样本不再有独立回撤硬门 → 退化即 is_good=false。
+            out.insert("is_good".into(), json!(!alpha_degenerate && cond_yearly));
         }
         Mode::Recent => {
             out.insert("mode".into(), json!("recent"));
@@ -414,38 +397,32 @@ pub(crate) fn judge(
                 compute_history_max_dd_excl_recent(&alpha_daily, recent_days, min_history_days)
             };
 
-            // 复利绝对收益直接取自 strategy_daily（与 alpha 退化无关）。
-            let cond_return_value =
-                recent.abs_return > RETURN_EPSILON || recent.alpha_return > RETURN_EPSILON;
+            // 收益侧三路 OR：绝对收益>ε 或 多头超额>ε 或 近期超额回撤<阈值。
+            // 退化时 alpha 派生两路不参与，且整体 is_good 强制 false（见文档契约）。
+            let cond_return_value = recent.abs_return > RETURN_EPSILON
+                || recent.alpha_return > RETURN_EPSILON
+                || recent.alpha_max_drawdown < max_dd_threshold;
             let cond_return = !alpha_degenerate && cond_return_value;
             if !alpha_degenerate && !cond_return {
                 reasons.push(format!(
-                    "recent abs_return {:.6} ≤ ε and alpha_return {:.6} ≤ ε",
-                    recent.abs_return, recent.alpha_return
+                    "recent all three metrics fail (abs_return={:.6}, alpha_return={:.6}, alpha_max_drawdown={:.6} ≥ threshold {:.6})",
+                    recent.abs_return, recent.alpha_return, recent.alpha_max_drawdown, max_dd_threshold
                 ));
             }
 
+            // 唯一保留的硬门：近期最大回撤严格小于「剔除 recent 窗口后」的历史最大回撤。
             let history_window_short = history_dd_excl.is_none() && !alpha_degenerate;
             let (cond_dd, history_dd_excl_value) = if alpha_degenerate {
                 (false, Value::Null)
             } else {
                 match history_dd_excl {
                     Some(h) => {
-                        let ok = recent.alpha_max_drawdown < max_dd_threshold
-                            && recent.alpha_max_drawdown < h;
+                        let ok = recent.alpha_max_drawdown < h;
                         if !ok {
-                            if recent.alpha_max_drawdown >= max_dd_threshold {
-                                reasons.push(format!(
-                                    "recent_alpha_max_drawdown {:.6} ≥ threshold {:.6}",
-                                    recent.alpha_max_drawdown, max_dd_threshold
-                                ));
-                            }
-                            if recent.alpha_max_drawdown >= h {
-                                reasons.push(format!(
-                                    "recent_alpha_max_drawdown {:.6} ≥ history_excl {:.6}",
-                                    recent.alpha_max_drawdown, h
-                                ));
-                            }
+                            reasons.push(format!(
+                                "recent_alpha_max_drawdown {:.6} ≥ history_excl {:.6}",
+                                recent.alpha_max_drawdown, h
+                            ));
                         }
                         (ok, json!(h))
                     }
@@ -508,6 +485,7 @@ fn year_metric_to_value(m: &YearMetric) -> Value {
     obj.insert("year".into(), json!(m.year));
     obj.insert("abs_return".into(), json!(m.abs_return));
     obj.insert("alpha_return".into(), json!(m.alpha_return));
+    obj.insert("alpha_max_drawdown".into(), json!(m.alpha_max_drawdown));
     obj.insert("days".into(), json!(m.days));
     obj.insert("is_complete_year".into(), json!(m.is_complete_year));
     obj.insert("year_passed".into(), json!(m.year_passed));
@@ -836,16 +814,8 @@ mod tests {
     }
 
     // ===========================================================================
-    // compute_history_max_dd_full / excl_recent
+    // compute_history_max_dd_excl_recent
     // ===========================================================================
-
-    #[test]
-    fn history_max_dd_full_known_value() {
-        let alpha = vec![0.05_f64, -0.10, -0.05, 0.02, 0.03];
-        let dd = compute_history_max_dd_full(&alpha);
-        let expected = (1.05_f64 - 0.89775) / 1.05;
-        assert!((dd - expected).abs() < 1e-10);
-    }
 
     /// Disjoint check, min_history_days=0 disables floor.
     #[test]
@@ -854,7 +824,7 @@ mod tests {
         alpha.extend(std::iter::repeat_n(0.001_f64, 100));
         alpha.extend(std::iter::repeat_n(-0.005_f64, 252));
         let excl = compute_history_max_dd_excl_recent(&alpha, 252, 0).unwrap();
-        let full = compute_history_max_dd_full(&alpha);
+        let full = local_max_drawdown_abs(&alpha);
         assert!(excl < 1e-6);
         assert!(full > 0.5);
         assert!((excl - full).abs() > 0.1);
@@ -1021,36 +991,121 @@ mod tests {
     // judge: history mode
     // ===========================================================================
 
+    /// 单年样本：strat 每日恒定；long/bench 由闭包按 index 生成（用于构造可控的 alpha）。
+    fn year_block(
+        year: i32,
+        n: usize,
+        strat_per_day: f64,
+        long_fn: impl Fn(usize) -> f64,
+        bench_fn: impl Fn(usize) -> f64,
+    ) -> (Vec<i32>, Vec<f64>, Vec<f64>, Vec<f64>) {
+        let start = chrono::NaiveDate::from_ymd_opt(year, 1, 2).unwrap();
+        let mut k = Vec::new();
+        let (mut s, mut b, mut l) = (Vec::new(), Vec::new(), Vec::new());
+        for i in 0..n {
+            k.push(date_key_from_nd(start + chrono::Duration::days(i as i64)));
+            s.push(strat_per_day);
+            l.push(long_fn(i));
+            b.push(bench_fn(i));
+        }
+        (k, s, b, l)
+    }
+
+    // long/bench 漂移方向相反、形状不同 → alpha 非退化。漂移远大于振荡时单调，
+    // 用于"超额大幅下行 / 上行"这类需要明确符号与回撤的场景。
+    fn drift_down_long(i: usize) -> f64 {
+        -0.0008 + 0.0003 * ((i % 3) as f64 - 1.0)
+    }
+    fn drift_up_bench(i: usize) -> f64 {
+        0.0008 + 0.0003 * ((i % 5) as f64 - 2.0)
+    }
+
+    /// history 三路 OR —— 仅靠「绝对收益>0」过关（超额下行：alpha_return<0 且当年回撤≥阈值）。
     #[test]
-    fn history_passes_when_all_conditions_met() {
-        let (k, s, b, l) = build_two_year_samples(0.001, 0.001);
-        let r = judge(Mode::History, &k, &s, &b, &l, 252, 0.20, 1.0, 120, 252, 0).unwrap();
-        assert_eq!(r.get("mode").and_then(|v| v.as_str()), Some("history"));
+    fn history_year_passes_via_abs_return_only() {
+        let (k, s, b, l) = year_block(2020, 130, 0.001, drift_down_long, drift_up_bench);
+        let r = judge(Mode::History, &k, &s, &b, &l, 252, 0.20, 0.20, 120, 252, 0).unwrap();
+        let ym = r.get("yearly_metrics").and_then(|v| v.as_array()).unwrap();
+        let y = &ym[0];
+        assert!(y["abs_return"].as_f64().unwrap() > 0.0);
+        assert!(y["alpha_return"].as_f64().unwrap() <= 0.0);
+        assert!(y["alpha_max_drawdown"].as_f64().unwrap() >= 0.20);
+        assert_eq!(r.get("is_good").and_then(|v| v.as_bool()), Some(true));
+    }
+
+    /// history 三路 OR —— 仅靠「当年超额回撤<阈值」过关（绝对/超额收益均为 0）。
+    #[test]
+    fn history_year_passes_via_year_dd_only() {
+        // strat=0 → abs_return=0；long==bench → alpha≡0 → alpha_return=0、year_dd=0<阈值。
+        let osc = |i: usize| 0.0003 * ((i % 3) as f64 - 1.0);
+        let (k, s, b, l) = year_block(2020, 130, 0.0, osc, osc);
+        let r = judge(Mode::History, &k, &s, &b, &l, 252, 0.20, 0.20, 120, 252, 0).unwrap();
+        let ym = r.get("yearly_metrics").and_then(|v| v.as_array()).unwrap();
+        let y = &ym[0];
+        assert!(y["abs_return"].as_f64().unwrap().abs() < 1e-9);
+        assert!(y["alpha_return"].as_f64().unwrap().abs() < 1e-9);
+        assert!(y["alpha_max_drawdown"].as_f64().unwrap() < 0.20);
         assert_eq!(
             r.get("alpha_degenerate").and_then(|v| v.as_bool()),
             Some(false)
         );
-        assert_eq!(
-            r.get("cond_yearly_passed").and_then(|v| v.as_bool()),
-            Some(true)
-        );
-        assert_eq!(
-            r.get("cond_history_dd_passed").and_then(|v| v.as_bool()),
-            Some(true)
-        );
+        assert_eq!(r.get("is_good").and_then(|v| v.as_bool()), Some(true));
+        assert_eq!(r.get("reason").and_then(|v| v.as_str()), Some(""));
+    }
+
+    /// history 三路 OR —— 仅靠「波动率归一多头超额>0」过关（abs=0，当年回撤≥极小阈值）。
+    #[test]
+    fn history_year_passes_via_alpha_return_only() {
+        // 小漂移、相对振荡较大 → alpha 上行但有下行日 → alpha_return>0 且 year_dd>1e-9。
+        let long = |i: usize| 0.0002 + 0.0006 * ((i % 3) as f64 - 1.0);
+        let bench = |i: usize| -0.0002 + 0.0006 * ((i % 5) as f64 - 2.0);
+        let (k, s, b, l) = year_block(2020, 130, 0.0, long, bench);
+        let r = judge(Mode::History, &k, &s, &b, &l, 252, 0.20, 1e-9, 120, 252, 0).unwrap();
+        let ym = r.get("yearly_metrics").and_then(|v| v.as_array()).unwrap();
+        let y = &ym[0];
+        assert!(y["abs_return"].as_f64().unwrap().abs() < 1e-9);
+        assert!(y["alpha_return"].as_f64().unwrap() > 0.0);
+        assert!(y["alpha_max_drawdown"].as_f64().unwrap() >= 1e-9);
         assert_eq!(r.get("is_good").and_then(|v| v.as_bool()), Some(true));
     }
 
+    /// 某完整年三路全败 → is_good=false，reason 点名该年。
     #[test]
-    fn history_fails_when_any_complete_year_both_metrics_negative() {
-        let (k, s, b, l) = build_two_year_samples(0.001, -0.001);
-        let r = judge(Mode::History, &k, &s, &b, &l, 252, 0.20, 1.0, 120, 252, 0).unwrap();
+    fn history_fails_when_year_fails_all_three() {
+        // strat<0（abs<0）；超额下行（alpha_return<0 且 year_dd≥阈值）。
+        let (k, s, b, l) = year_block(2020, 130, -0.001, drift_down_long, drift_up_bench);
+        let r = judge(Mode::History, &k, &s, &b, &l, 252, 0.20, 0.20, 120, 252, 0).unwrap();
         assert_eq!(r.get("is_good").and_then(|v| v.as_bool()), Some(false));
         let reason = r.get("reason").and_then(|v| v.as_str()).unwrap_or("");
         assert!(
-            reason.contains("2021") || reason.contains("2020"),
-            "reason should mention failing year, got: {reason}"
+            reason.contains("2020") && reason.contains("all three"),
+            "reason should name failing year and all-three, got: {reason}"
         );
+        // 全样本回撤硬门已取消，相关 key 不再返回。
+        assert!(!r.contains_key("history_alpha_max_drawdown"));
+        assert!(!r.contains_key("cond_history_dd_passed"));
+    }
+
+    /// 逐年 AND：一年合格、一年三路全败 → 整体不通过。
+    #[test]
+    fn history_requires_all_complete_years_pass() {
+        let (mut k, mut s, mut b, mut l) =
+            year_block(2020, 130, 0.001, drift_down_long, drift_up_bench); // 年1：靠 abs 过
+        let (k2, s2, b2, l2) = year_block(2021, 130, -0.001, drift_down_long, drift_up_bench); // 年2：全败
+        k.extend(k2);
+        s.extend(s2);
+        b.extend(b2);
+        l.extend(l2);
+        let r = judge(Mode::History, &k, &s, &b, &l, 252, 0.20, 0.20, 120, 252, 0).unwrap();
+        assert_eq!(
+            r.get("complete_year_count").and_then(|v| v.as_u64()),
+            Some(2)
+        );
+        assert_eq!(
+            r.get("cond_yearly_passed").and_then(|v| v.as_bool()),
+            Some(false)
+        );
+        assert_eq!(r.get("is_good").and_then(|v| v.as_bool()), Some(false));
     }
 
     #[test]
@@ -1062,37 +1117,13 @@ mod tests {
         assert!(reason.contains("no complete year") || reason.contains("complete year"));
     }
 
+    /// alpha 退化（long vol == 0）→ is_good=false，且不再返回全样本回撤相关 key。
     #[test]
-    fn history_fails_when_max_dd_exceeds_threshold() {
-        let mut k = Vec::new();
-        let mut s = Vec::new();
-        let mut b = Vec::new();
-        let mut l = Vec::new();
-        for i in 0..150 {
-            let nd = chrono::NaiveDate::from_ymd_opt(2020, 1, 2).unwrap()
-                + chrono::Duration::days(i as i64);
-            k.push(date_key_from_nd(nd));
-            s.push(0.002);
-            b.push(0.001 + 0.0005 * ((i % 3) as f64));
-            l.push(-(0.001 + 0.0005 * ((i % 3) as f64)));
-        }
-        let r = judge(Mode::History, &k, &s, &b, &l, 252, 0.20, 0.20, 120, 252, 0).unwrap();
-        assert_eq!(r.get("is_good").and_then(|v| v.as_bool()), Some(false));
-        let dd = r
-            .get("history_alpha_max_drawdown")
-            .and_then(|v| v.as_f64())
-            .expect("history_alpha_max_drawdown must be set when not degenerate");
-        assert!(dd > 0.20);
-    }
-
-    /// F3 fix: alpha degenerate (long vol == 0) must NOT trivially pass cond_history_dd.
-    #[test]
-    fn history_alpha_degenerate_does_not_trivially_pass() {
+    fn history_alpha_degenerate_is_not_good() {
         let start = chrono::NaiveDate::from_ymd_opt(2020, 1, 2).unwrap();
         let keys = consecutive_keys(start, 130);
-        let s = vec![0.001_f64; 130];
-        // long vol == 0 -> vol_adjusted returns None -> alpha_degenerate
-        let long = vec![0.0_f64; 130];
+        let s = vec![0.001_f64; 130]; // abs_return>0，但退化时强制 is_good=false
+        let long = vec![0.0_f64; 130]; // long vol == 0 -> 退化
         let bench: Vec<f64> = (0..130)
             .map(|i| 0.001 + 0.0005 * ((i % 3) as f64))
             .collect();
@@ -1114,70 +1145,16 @@ mod tests {
             r.get("alpha_degenerate").and_then(|v| v.as_bool()),
             Some(true)
         );
-        assert_eq!(
-            r.get("cond_history_dd_passed").and_then(|v| v.as_bool()),
-            Some(false)
-        );
         assert_eq!(r.get("is_good").and_then(|v| v.as_bool()), Some(false));
-        assert!(matches!(
-            r.get("history_alpha_max_drawdown"),
-            Some(Value::Null)
-        ));
+        assert!(!r.contains_key("history_alpha_max_drawdown"));
+        assert!(!r.contains_key("cond_history_dd_passed"));
     }
 
-    /// F8 fix: history degenerate -> history_alpha_max_drawdown is Null.
-    #[test]
-    fn history_alpha_max_drawdown_is_null_when_degenerate() {
-        let start = chrono::NaiveDate::from_ymd_opt(2020, 1, 2).unwrap();
-        let keys = consecutive_keys(start, 130);
-        let s = vec![0.001_f64; 130];
-        let long = vec![0.0_f64; 130];
-        let bench: Vec<f64> = (0..130)
-            .map(|i| 0.001 + 0.0005 * ((i % 3) as f64))
-            .collect();
-        let r = judge(
-            Mode::History,
-            &keys,
-            &s,
-            &bench,
-            &long,
-            252,
-            0.20,
-            1.0,
-            120,
-            252,
-            0,
-        )
-        .unwrap();
-        assert!(matches!(
-            r.get("history_alpha_max_drawdown"),
-            Some(Value::Null)
-        ));
-    }
-
-    /// F11 fix: year returns near 0 use RETURN_EPSILON.
+    /// 年度收益接近 0 时用 RETURN_EPSILON：abs≈0、超额下行 → 三路全败 → is_good=false。
     #[test]
     fn history_year_passed_uses_epsilon() {
-        let start = chrono::NaiveDate::from_ymd_opt(2020, 1, 2).unwrap();
-        let keys = consecutive_keys(start, 130);
-        let s = vec![1e-12_f64; 130];
-        let same: Vec<f64> = (0..130)
-            .map(|i| 0.001 + 0.0005 * ((i % 3) as f64))
-            .collect();
-        let r = judge(
-            Mode::History,
-            &keys,
-            &s,
-            &same,
-            &same,
-            252,
-            0.20,
-            1.0,
-            120,
-            252,
-            0,
-        )
-        .unwrap();
+        let (k, s, b, l) = year_block(2020, 130, 1e-12, drift_down_long, drift_up_bench);
+        let r = judge(Mode::History, &k, &s, &b, &l, 252, 0.20, 0.20, 120, 252, 0).unwrap();
         assert_eq!(r.get("is_good").and_then(|v| v.as_bool()), Some(false));
     }
 
@@ -1309,5 +1286,98 @@ mod tests {
             r.get("history_alpha_max_drawdown_excl_recent"),
             Some(Value::Null)
         ));
+    }
+
+    /// recent 三路 OR —— 仅靠「近期超额回撤<阈值」过关（abs<0、alpha_return≈0），
+    /// 且近期回撤严格小于历史回撤这一硬门成立 → is_good=true。
+    #[test]
+    fn recent_passes_via_dd_branch_only() {
+        // 头段 148 天超额大幅下行（历史回撤大）；尾段 252 天 long/bench≡0 → 近期 alpha≡0。
+        let head = 148usize;
+        let total = head + 252;
+        let start = chrono::NaiveDate::from_ymd_opt(2020, 1, 1).unwrap();
+        let keys = consecutive_keys(start, total);
+        let s = vec![-0.0001_f64; total]; // 近期 abs_return<0
+        let l: Vec<f64> = (0..total)
+            .map(|i| if i < head { drift_down_long(i) } else { 0.0 })
+            .collect();
+        let b: Vec<f64> = (0..total)
+            .map(|i| if i < head { drift_up_bench(i) } else { 0.0 })
+            .collect();
+        let r = judge(
+            Mode::Recent,
+            &keys,
+            &s,
+            &b,
+            &l,
+            252,
+            0.20,
+            0.20,
+            120,
+            252,
+            60,
+        )
+        .unwrap();
+        assert_eq!(
+            r.get("alpha_degenerate").and_then(|v| v.as_bool()),
+            Some(false)
+        );
+        assert!(r.get("recent_abs_return").and_then(|v| v.as_f64()).unwrap() < 0.0);
+        assert!(
+            r.get("recent_alpha_max_drawdown")
+                .and_then(|v| v.as_f64())
+                .unwrap()
+                < 0.20
+        );
+        assert_eq!(
+            r.get("cond_recent_return_passed").and_then(|v| v.as_bool()),
+            Some(true)
+        );
+        assert_eq!(
+            r.get("cond_recent_dd_passed").and_then(|v| v.as_bool()),
+            Some(true)
+        );
+        assert_eq!(r.get("is_good").and_then(|v| v.as_bool()), Some(true));
+    }
+
+    /// 历史回撤硬门是严格小于：近期回撤恰好等于历史回撤时判 False。
+    #[test]
+    fn recent_strict_history_rejects_equal_dd() {
+        // 头段 [0,252) 与尾段 [252,504) 取相同的周期化形状 → 两窗 alpha 逐点相等 →
+        // recent_dd == history_excl，严格 `<` 应为 false。
+        let total = 504usize;
+        let start = chrono::NaiveDate::from_ymd_opt(2019, 1, 1).unwrap();
+        let keys = consecutive_keys(start, total);
+        let s = vec![0.001_f64; total]; // 收益侧 OR 通过（abs_return>0）
+        let l: Vec<f64> = (0..total)
+            .map(|i| 0.0002 + 0.0006 * (((i % 252) % 3) as f64 - 1.0))
+            .collect();
+        let b: Vec<f64> = (0..total)
+            .map(|i| -0.0002 + 0.0006 * (((i % 252) % 5) as f64 - 2.0))
+            .collect();
+        let r = judge(
+            Mode::Recent,
+            &keys,
+            &s,
+            &b,
+            &l,
+            252,
+            0.20,
+            0.20,
+            120,
+            252,
+            60,
+        )
+        .unwrap();
+        assert_eq!(
+            r.get("cond_recent_return_passed").and_then(|v| v.as_bool()),
+            Some(true)
+        );
+        assert_eq!(
+            r.get("cond_recent_dd_passed").and_then(|v| v.as_bool()),
+            Some(false),
+            "recent_dd == history_excl must NOT pass the strict `<` gate"
+        );
+        assert_eq!(r.get("is_good").and_then(|v| v.as_bool()), Some(false));
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -339,7 +339,7 @@ impl PyWeightBacktest {
         hashmap_to_pydict(py, &map)
     }
 
-    #[pyo3(signature = (mode="history", target_vol=0.20, max_dd_threshold=0.20, min_year_days=120, recent_days=252, min_history_days=60))]
+    #[pyo3(signature = (mode="history", target_vol=0.20, max_dd_threshold=0.20, min_year_days=200, recent_days=252, min_history_days=60))]
     #[allow(clippy::too_many_arguments)]
     fn is_good_strategy<'py>(
         &self,


### PR DESCRIPTION
## 背景

SKZ-9：调整 `is_good_strategy` 的 history / recent 判定口径，并在 HTML 报告中补全两种模式的完整判定。版本 0.3.2 → **0.4.0**。

## 判定口径变更（BREAKING）

### history 模式
- `min_year_days` 默认 **120 → 200**。
- 每个完整自然年改为**三路 OR**：`绝对收益>0` 或 `波动率归一多头超额>0` 或 `当年多头超额最大回撤 < max_dd_threshold`；所有完整年都合格才 `is_good`。
- **取消**原先跨全样本的回撤独立硬门，回撤改为逐年计算并入年度 OR。

### recent 模式
- 收益侧改为**三路 OR**：`绝对收益>0` 或 `波动率归一多头超额>0` 或 `近期多头超额回撤 < max_dd_threshold`。
- 唯一保留的 AND 硬门：近期最大回撤**严格小于**「剔除 recent 窗口后」的历史最大回撤（等于时判 False）。

### 返回 dict
- history 移除 `history_alpha_max_drawdown`、`cond_history_dd_passed`；`yearly_metrics` 每项新增 `alpha_max_drawdown`。
- recent 的 `cond_recent_dd_passed` 现仅表示"严格小于历史回撤"；`cond_recent_return_passed` 并入"回撤<阈值"的 OR（key 名不变）。

## 报告

`generate_backtest_report` 的「策略审核」tab 此前只渲染 history 判定。现同时渲染 **history + recent 两张判定卡**，并新增 native `<details>` 折叠按钮「查看详细判定信息」，展开后逐字段列出两种模式的判定细节（含原始 reason）。无新增 JS 依赖。

## 下游（skz）需同步

判定口径无需改动（仍只取 `is_good`），但 `describe_review_failure` 解析的 `reason` 文案已变，且 `segment_stats.py` 若引用了已移除的 `history_alpha_max_drawdown` / `cond_history_dd_passed` 需改用 `yearly_metrics[].alpha_max_drawdown` 或移除。

## 测试

- Rust：三路 OR 每路单独触发 + 逐年 AND + recent OR + 历史回撤等于边界判 False（202 tests / fmt / clippy 全绿）。
- Python：键集更新、逐年回撤断言、报告双模式判定集成测试（281 passed / ruff / basedpyright 全绿）。

关联 issue：SKZ-9
