### PR TITLE
SKZ-112: compact backtest result JSON

### DIFF
--- a/python/tests/test_result.py
+++ b/python/tests/test_result.py
@@ -115,6 +115,14 @@ def test_pairs_dist_grouped(result: BacktestResult) -> None:
         assert len(arr) == len(pd_.holds[k])
 
 
+def test_pairs_dist_json_payload_is_compact(result: BacktestResult) -> None:
+    pairs_dist = result.to_dict()["pairs_dist"]
+    for values in pairs_dist["pnl_pct"].values():
+        assert all(round(v, 4) == v for v in values)
+    for values in pairs_dist["holds"].values():
+        assert all(isinstance(v, int) for v in values)
+
+
 # ---------------------------------------------------------------------------
 # C 按需计算（cached_property）
 # ---------------------------------------------------------------------------
@@ -189,6 +197,18 @@ def test_to_dict_json_safe(result: BacktestResult) -> None:
     assert "drawdowns" in d_full
     assert "curves_voladj" in d_full
     assert isinstance(s, str)
+
+
+def test_to_dict_does_not_include_raw_pairs(result: BacktestResult) -> None:
+    def has_pairs_key(obj: object) -> bool:
+        if isinstance(obj, dict):
+            return "pairs" in obj or any(has_pairs_key(v) for v in obj.values())
+        if isinstance(obj, list):
+            return any(has_pairs_key(v) for v in obj)
+        return False
+
+    assert not has_pairs_key(result.to_dict())
+    assert not has_pairs_key(result.to_dict(full=True))
 
 
 def test_stats_by_side_keys(result: BacktestResult) -> None:

--- a/python/wbt/result.py
+++ b/python/wbt/result.py
@@ -313,8 +313,8 @@ class BacktestResult:
         for direction, sub in agg.groupby("交易方向"):
             key = str(direction)
             # 盈亏比例单位 BP → 百分比
-            pnl_pct[key] = sub["盈亏比例"].to_numpy(dtype=float) / 100.0
-            holds[key] = sub["持仓K线数"].to_numpy(dtype=float)
+            pnl_pct[key] = np.round(sub["盈亏比例"].to_numpy(dtype=float) / 100.0, 4)
+            holds[key] = sub["持仓K线数"].to_numpy(dtype=int)
         return PairsDist(pnl_pct=pnl_pct, holds=holds)
 
     # -------------------------------------------------------- cached (按需)

--- a/src/core/report.rs
+++ b/src/core/report.rs
@@ -62,7 +62,6 @@ impl From<Report> for Value {
                 symbol.symbol,
                 json!({
                     "daily": symbol.daily,
-                    "pairs": symbol.pair,
                 }),
             );
         }
@@ -218,6 +217,9 @@ mod tests {
         assert!(val.is_object());
         let obj = val.as_object().unwrap();
         assert!(obj.contains_key("TEST"));
+        let symbol_obj = obj["TEST"].as_object().unwrap();
+        assert!(symbol_obj.contains_key("daily"));
+        assert!(!symbol_obj.contains_key("pairs"));
         assert!(obj.contains_key("品种等权日收益"));
         assert!(obj.contains_key("绩效评价"));
         assert!(obj.contains_key("多头统计"));


### PR DESCRIPTION
Closes SKZ-112

## Summary

- remove raw `pairs` from the legacy Rust `Report -> Value` JSON payload
- compact `BacktestResult.pairs_dist` JSON output by rounding `pnl_pct` to 4 decimals and serializing `holds` as ints
- add Python and Rust regression coverage for compact result JSON behavior

## Verification

- `cargo test`
- `cd python && uv run --extra dev pytest -q`
- `cd python && uv run --extra dev ruff format --check .`
- `cd python && uv run --extra dev ruff check .`
