### PR TITLE
SKZ-112: bump release version to 0.4.3

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wbt"
-version = "0.4.2"
+version = "0.4.3"
 edition = "2024"
 description = "Weight-based backtesting engine for quantitative trading"
 license = "MIT"


### PR DESCRIPTION
Bump wbt version from 0.4.2 to 0.4.3 for the SKZ-112 release.\n\nValidation:\n- cargo metadata --no-deps --format-version 1 reports wbt 0.4.3\n- cargo test --lib: 220 passed\n- uv run --extra dev maturin build --sdist --out dist built wbt-0.4.3 sdist and local macOS arm64 wheel\n- cargo publish -p wbt --dry-run succeeded