### PR TITLE
fix(python): 去掉 mock 的 lru_cache，收窄 result 的异常吞没

### DIFF
--- a/python/wbt/mock.py
+++ b/python/wbt/mock.py
@@ -6,7 +6,6 @@
 from __future__ import annotations
 
 import hashlib
-from functools import lru_cache
 
 import numpy as np
 import pandas as pd
@@ -109,7 +108,6 @@ def _build_phase_arrays(n: int) -> tuple[np.ndarray, np.ndarray]:
     return trends, volatilities
 
 
-@lru_cache(maxsize=10)
 def mock_symbol_kline(
     symbol: str,
     freq: str,
@@ -221,7 +219,6 @@ def mock_symbol_kline(
     )
 
 
-@lru_cache(maxsize=10)
 def mock_weights(
     symbols: tuple[str, ...] = DEFAULT_SYMBOLS,
     freq: str = "日线",

--- a/python/wbt/result.py
+++ b/python/wbt/result.py
@@ -12,8 +12,8 @@
 
 from __future__ import annotations
 
-import contextlib
 import datetime as _dt
+import logging
 from dataclasses import dataclass
 from functools import cached_property
 from typing import TYPE_CHECKING, Any
@@ -25,6 +25,8 @@ from wbt.top_drawdowns import top_drawdowns
 
 if TYPE_CHECKING:
     from wbt.backtest import WeightBacktest
+
+logger = logging.getLogger(__name__)
 
 # curves 键 → daily_return / alpha 的来源列
 _CURVE_KEYS = ("多空", "多头", "空头", "基准", "超额")
@@ -420,9 +422,13 @@ class BacktestResult:
         n = len(self.dates)
         if n > 0:
             sdt = pd.Timestamp(self.dates[max(0, n - self.yearly_days)])
-            # 区间过短等异常时降级为仅全样本
-            with contextlib.suppress(Exception):
+            # 区间过短等异常时降级为仅全样本。segment_stats 的错误在 Rust FFI 边界统一
+            # 转成 PyException（Python Exception 基类），无法收窄到更具体的类型，故这里
+            # 捕获 Exception 但留一行 debug 痕迹，避免真实 bug 被静默成"近1年面板消失"。
+            try:
                 out["近1年"] = self._wb.segment_stats(sdt=sdt, kind="多空")
+            except Exception:
+                logger.debug("segment_stats 近1年区间计算失败，降级为仅全样本", exc_info=True)
         return out
 
     # ---------------------------------------------------------------- to_dict


### PR DESCRIPTION
## 背景

`project-coding-quality` 稳定性体检（commit fcc3ba1，得分 94/100）发现的两处**低危**项，本 PR 一并修复。均为语义等价的收敛改动，不影响公共 API 行为。

## 改动

### ① `mock.py` — 去掉 `lru_cache`（内存 + 共享可变双隐患）

`mock_symbol_kline` / `mock_weights` 原本带 `@lru_cache(maxsize=10)`，直接返回可变 DataFrame 对象本身：

- **(a) 共享可变**：`lru_cache` 每次返回同一对象引用，调用方一旦 in-place 修改（`df["x"]=...` / `inplace=True`）就会污染缓存，导致后续同参调用拿到脏数据 —— 隐蔽的"跨调用串味"bug。
- **(b) 缓存膨胀**：细频率 + 长区间下单帧极大（如 `1分钟` × 15 年 ≈ 90 万行/品种），`maxsize=10` 意味最多驻留 10 份此量级 DataFrame，常驻内存可达数百 MB~GB 且不主动释放。

`mock_*` 是纯向量化造数函数，全测试套件仅 1 处调用，缓存收益极低 → 直接移除（YAGNI），两个隐患一并消除，输出完全等价。

### ② `result.py` — 收窄异常吞没

`segment_comparison` 里 `contextlib.suppress(Exception)` 会**静默吞掉全部异常**，真实 bug 会被藏成"近1年面板悄悄消失"。

`segment_stats` 的错误在 Rust FFI 边界统一转成 `PyException`（Python `Exception` 基类），**无法收窄到更具体类型**，故保留捕获 `Exception`，但补一行 `logger.debug(..., exc_info=True)` 留痕，既保留"区间过短降级为仅全样本"的原行为，又不再让意外错误无声无息。

## 验证

在 `python/` 下（`uv sync --extra dev` 后）：

- `ruff format --check` → 2 files already formatted
- `ruff check --no-fix` → All checks passed!
- `basedpyright` → **0 errors, 0 warnings, 0 notes**
- `pytest -q` → **291 passed in 15.55s**

🤖 Generated with [Claude Code](https://claude.com/claude-code)
